### PR TITLE
CHI-101 Phase A: Lean→Slang verification scaffolding + F1 fix

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   static-checks:
     name: Formatting (clang-format, file format)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -345,6 +345,14 @@ platform/windows/godot_res.res
 # Visual Studio Code workspace file
 *.code-workspace
 
+# Lean (Lake) build artifacts
+lean/.lake/
+lean/lake-packages/
+lean/build/
+
+# slang_validate build artifacts
+tests/slang_validate/build/
+
 # Scons construction environment dump
 .scons_env.json
 

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -20,6 +20,7 @@ open LeanSlang
 private def kernels : List (String × SlangShaderModule) :=
   [ ("frame_energy",    FrameEnergy.shader)
   , ("framing_cursor",  FramingCursor.shader)
+  , ("jitter_append",   JitterAppend.shader)
   , ("vad_gate",        VadGate.shader)
   ]
 

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -1,0 +1,32 @@
+import LeanSlang
+import Speech.SlangCodegen
+
+/-!
+# `emit_shaders` — Lake exe dumping every Slang shader to disk
+
+For each `Speech.SlangCodegen.*` kernel, writes the emitted Slang
+source to `<outDir>/<name>.slang`. Used as input to slangc for
+syntactic / semantic validation beyond the `native_decide` text
+fixtures (see `tests/slang_validate/Makefile`).
+
+Usage:
+
+    lake exe emit_shaders /path/to/output/dir
+-/
+
+open Speech.SlangCodegen
+open LeanSlang
+
+private def kernels : List (String × SlangShaderModule) :=
+  [ ("frame_energy", FrameEnergy.shader)
+  , ("vad_gate",     VadGate.shader)
+  ]
+
+def main (args : List String) : IO UInt32 := do
+  let outDir := args.headD "."
+  IO.FS.createDirAll outDir
+  for (name, m) in kernels do
+    let path := outDir ++ "/" ++ name ++ ".slang"
+    IO.FS.writeFile path (LeanSlang.emit m ++ "\n")
+    IO.println s!"wrote {path}"
+  return 0

--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -18,8 +18,9 @@ open Speech.SlangCodegen
 open LeanSlang
 
 private def kernels : List (String × SlangShaderModule) :=
-  [ ("frame_energy", FrameEnergy.shader)
-  , ("vad_gate",     VadGate.shader)
+  [ ("frame_energy",    FrameEnergy.shader)
+  , ("framing_cursor",  FramingCursor.shader)
+  , ("vad_gate",        VadGate.shader)
   ]
 
 def main (args : List String) : IO UInt32 := do

--- a/lean/Speech.lean
+++ b/lean/Speech.lean
@@ -1,0 +1,25 @@
+import Speech.SlangCodegen
+
+/-!
+# `Speech` — godot-speech kernels in Lean → LeanSlang DSL
+
+CHI-101 Phase A. Mirrors TOOL_cloth_dynamics's `Cloth` Lean lib: every
+deterministic V-Sekai-side speech kernel and the VAD-gating policy are
+expressed as a `LeanSlang.SlangShaderModule`, then pinned by
+`native_decide` against a reference emit string and bit-exact-tested
+against a CPU reference in `tests/slang_validate/`.
+
+Upstream-pinned components (libopus internals, libsamplerate internals,
+Silero VAD weights, whisper.cpp transcription path) sit outside this
+boundary. Only V-Sekai-side deterministic bits get the Lean treatment.
+
+Submodules live under `Speech.SlangCodegen.*`. First kernels:
+
+* `Speech.SlangCodegen.FrameEnergy` — RMS sum-of-squares per 480-sample
+  10 ms frame at 48 kHz. Source signal for energy-based VAD fallback
+  and for diagnostics on the captured mic stream.
+* `Speech.SlangCodegen.VadGate` — hysteresis state machine that turns
+  per-frame VAD scores (from Silero) into a gated boolean stream with
+  enter/exit thresholds and hangover frames. The classifier itself is
+  upstream-pinned; only the gating policy on top is formalized here.
+-/

--- a/lean/Speech.lean
+++ b/lean/Speech.lean
@@ -18,6 +18,11 @@ Submodules live under `Speech.SlangCodegen.*`. First kernels:
 * `Speech.SlangCodegen.FrameEnergy` — RMS sum-of-squares per 480-sample
   10 ms frame at 48 kHz. Source signal for energy-based VAD fallback
   and for diagnostics on the captured mic stream.
+* `Speech.SlangCodegen.FramingCursor` — capture-buffer framing cursor
+  policy: integer division of `(carry + newSamples)` by `frameSize`
+  per audio-thread tick. Encodes the safe form of the loop currently
+  in `speech_processor.cpp:130`, which uses unsigned subtraction and
+  underflows when `resampled_frame_count < frameSize`.
 * `Speech.SlangCodegen.VadGate` — hysteresis state machine that turns
   per-frame VAD scores (from Silero) into a gated boolean stream with
   enter/exit thresholds and hangover frames. The classifier itself is

--- a/lean/Speech/SlangCodegen.lean
+++ b/lean/Speech/SlangCodegen.lean
@@ -1,5 +1,6 @@
 import Speech.SlangCodegen.FrameEnergy
 import Speech.SlangCodegen.FramingCursor
+import Speech.SlangCodegen.JitterAppend
 import Speech.SlangCodegen.VadGate
 
 /-!

--- a/lean/Speech/SlangCodegen.lean
+++ b/lean/Speech/SlangCodegen.lean
@@ -1,0 +1,22 @@
+import Speech.SlangCodegen.FrameEnergy
+import Speech.SlangCodegen.VadGate
+
+/-!
+# `Speech.SlangCodegen` — Slang shader codegen umbrella
+
+Each submodule produces a `LeanSlang.SlangShaderModule` for one of the
+godot-speech audio-thread kernels. Pinned `native_decide` fixtures
+assert the emission text against a hand-checked reference per kernel.
+
+Layout convention (same as `Cloth.SlangCodegen`):
+
+- `shader   : SlangShaderModule`
+- `expected : String`
+- two `example` lemmas: `emit shader = expected` and
+  `shader.entryPointName = "main"`.
+
+We don't run audio on the GPU. Both `slangc-cpp` (production target)
+and `slangc-metal` (discipline target) must build clean from each
+emitted `.slang` source — the Metal compile is a free portability
+check that surfaces hidden CPU assumptions in the spec.
+-/

--- a/lean/Speech/SlangCodegen.lean
+++ b/lean/Speech/SlangCodegen.lean
@@ -1,4 +1,5 @@
 import Speech.SlangCodegen.FrameEnergy
+import Speech.SlangCodegen.FramingCursor
 import Speech.SlangCodegen.VadGate
 
 /-!

--- a/lean/Speech/SlangCodegen/FrameEnergy.lean
+++ b/lean/Speech/SlangCodegen/FrameEnergy.lean
@@ -1,0 +1,116 @@
+import LeanSlang
+
+/-!
+# `Speech.SlangCodegen.FrameEnergy` — sum-of-squares per 10 ms frame
+
+First kernel ported into the godot-speech Lean → LeanSlang DSL
+pipeline. Computes, per 480-sample mono PCM frame at 48 kHz, the
+unnormalized energy
+
+  energy[f] = Σ_{s=0..479} (samples[f·480 + s])²
+
+where `samples` is float32 PCM in the range [-1, 1] (the form Godot's
+`AudioEffectCapture` already delivers; the s16 path multiplies by
+1/32768 once at capture). One thread per output frame.
+
+Why unnormalized: callers want either (a) the raw sum for adaptive
+floor tracking, or (b) `sqrt(energy / 480)` for RMS in volume units.
+Doing the divide and sqrt here would lock callers out of (a).
+
+Bindings (set 0):
+
+  0  ConstantBuffer<FrameEnergyParams> { uint numFrames; uint samplesPerFrame; }
+  1  StructuredBuffer<float>   samples    length ≥ numFrames · samplesPerFrame
+  2  RWStructuredBuffer<float> energy     length = numFrames
+
+`samplesPerFrame` is a constant `480` for the godot-speech runtime, but
+keeping it as a uniform avoids baking the constant into the kernel and
+matches the Saxpby / Spmv idiom in cloth_dynamics. Accumulation is
+strict left-to-right fp32 — both the slangc-cpp emit and the CPU
+reference in `tests/slang_validate/frame_energy_test.cpp` must perform
+the sum in the same order to remain bit-exact.
+
+The pinned reference text below is asserted by `native_decide`. Any
+drift in `LeanSlang.Emit` that affects this output trips here. To
+regenerate after a deliberate change, run
+`lake exe emit_shaders /tmp/emit && cat /tmp/emit/frame_energy.slang`
+and replace `expected` with the new output.
+-/
+
+namespace Speech.SlangCodegen.FrameEnergy
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+
+/-- Per-frame energy kernel. One thread per output frame; each thread
+    walks its 480-sample slice in order. -/
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "FrameEnergyParams"
+        , fields :=
+            [ ⟨"numFrames",       uintTy, Semantic.none, none, none, .qIn⟩
+            , ⟨"samplesPerFrame", uintTy, Semantic.none, none, none, .qIn⟩ ] } ]
+  , globals :=
+      [ ⟨"params",  .const "FrameEnergyParams",  Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"samples", .roBuf floatTy,              Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"energy",  .rwBuf floatTy,              Semantic.none, some 2, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit uintTy  "f" (.member (.var "tid") "x")
+        , .ifNoElse (.bin ">=" (.var "f") (.member (.var "params") "numFrames"))
+            [ .ret none ]
+        , .declInit uintTy  "base"
+            (.bin "*" (.var "f") (.member (.var "params") "samplesPerFrame"))
+        , .declInit floatTy "acc" (.litFloat 0.0)
+        , .forCount "s" (.litUint 0) (.member (.var "params") "samplesPerFrame")
+            [ .declInit floatTy "x"
+                (.index (.var "samples") (.bin "+" (.var "base") (.var "s")))
+            , .assign (.var "acc")
+                (.call "fma" [.var "x", .var "x", .var "acc"])
+            ]
+        , .assign (.index (.var "energy") (.var "f")) (.var "acc")
+        ] }] }
+
+/-- Pinned reference emission. Drift in `LeanSlang.Emit` that affects
+    this output trips `native_decide` below. Update both this string and
+    the kernel in lockstep. -/
+def expected : String :=
+"struct FrameEnergyParams {
+  uint numFrames;
+  uint samplesPerFrame;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<FrameEnergyParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> samples;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<float> energy;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint f = tid.x;
+  if ((f >= params.numFrames)) {
+    return;
+  }
+  uint base = (f * params.samplesPerFrame);
+  float acc = 0.000000;
+  for (uint s = 0u; s < params.samplesPerFrame; ++s) {
+    float x = samples[(base + s)];
+    acc = fma(x, x, acc);
+  }
+  energy[f] = acc;
+}"
+
+/-- The pretty-printer matches the pinned reference. -/
+example : LeanSlang.emit shader = expected := by native_decide
+
+/-- The kernel's entry-point name is `main`. -/
+example : shader.entryPointName = "main" := by native_decide
+
+end Speech.SlangCodegen.FrameEnergy

--- a/lean/Speech/SlangCodegen/FramingCursor.lean
+++ b/lean/Speech/SlangCodegen/FramingCursor.lean
@@ -1,0 +1,157 @@
+import LeanSlang
+
+/-!
+# `Speech.SlangCodegen.FramingCursor` — capture-buffer framing policy
+
+CHI-101 Phase A. Encodes the cursor arithmetic that
+`SpeechProcessor::_mix_audio` runs every audio-thread tick: given
+the carry-over from the previous tick and the count of newly
+resampled samples this tick, how many full 480-sample (10 ms) frames
+can be emitted, and how many samples are left over to carry forward?
+
+## Policy (math)
+
+```
+total          = carry + newSamples
+framesEmitted  = total / frameSize       // integer division
+nextCarry      = total mod frameSize     // 0 ≤ nextCarry < frameSize
+```
+
+That's it. Both quantities are exact integer arithmetic — no
+floating point, no thresholds, no hysteresis. The invariant is:
+
+  carry · 1 + newSamples · 1  =  framesEmitted · frameSize  +  nextCarry
+
+and `0 ≤ nextCarry < frameSize`.
+
+## Why this kernel exists
+
+`speech_processor.cpp:130` (as of this writing) implements the same
+policy with a different formulation:
+
+```cpp
+while (capture_real_array_offset
+       < resampled_frame_count - SPEECH_SETTING_BUFFER_FRAME_COUNT) {
+  // emit a 480-frame packet
+  capture_real_array_offset += SPEECH_SETTING_BUFFER_FRAME_COUNT;
+}
+```
+
+That subtraction is `uint32_t`. If `resampled_frame_count < 480`
+(degenerate first-tick or resampler underrun), the right-hand side
+underflows to ~4 G and the loop reads past the buffer end. Even in
+non-degenerate cases, the strict `<` mis-fires the boundary at
+`resampled_frame_count == capture_real_array_offset + 480`.
+
+The Lean policy above is immune to both: integer division can't
+underflow, and the boundary is `total / frameSize` which gives 1
+for `total == frameSize` exactly. The bit-exact harness in
+`tests/slang_validate/framing_cursor_test.cpp` runs both the kernel
+and the literal `speech_processor.cpp` formulation over a fixture
+that triggers the underflow — they disagree, kernel right.
+
+## Shape
+
+The C++ runs as a single-thread loop per audio-thread tick (with
+state held in `capture_real_array_offset`). The kernel mirrors this:
+single-thread dispatch (`[numthreads(1, 1, 1)]`) that walks
+`numTicks` simulated ticks in order, carrying state via `stateIO`.
+
+For runtime use, dispatch with `numTicks = 1` per audio-thread tick.
+For batch verification against recorded captures, dispatch with
+`numTicks = N` in one shot.
+
+## Bindings (set 0)
+
+  0  ConstantBuffer<FramingCursorParams> {
+       uint numTicks;
+       uint frameSize;          // 480 for 10 ms @ 48 kHz
+     }
+  1  StructuredBuffer<uint>    newSamples       length = numTicks
+  2  RWStructuredBuffer<uint>  framesEmitted    length = numTicks
+  3  RWStructuredBuffer<uint>  stateIO          length = 1
+       // [0] = carry samples in the buffer (0..frameSize - 1)
+
+The kernel does NOT emit per-frame data — only the *count* of frames
+that would be emitted per tick. The actual frame-data copy is a
+parallel kernel (one thread per emitted frame) that can be added in
+a follow-up; for the cursor-policy diff we only need the count and
+the carry evolution.
+-/
+
+namespace Speech.SlangCodegen.FramingCursor
+
+open LeanSlang
+
+private def uintTy : SlangType := .scalar .uint
+
+/-- Capture-buffer framing-cursor policy. Single-thread dispatch
+    walks `numTicks` ticks in order; per tick, integer-divide
+    `(carry + newSamples[i])` by `frameSize` to get
+    `framesEmitted[i]`; the remainder becomes the next carry. -/
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "FramingCursorParams"
+        , fields :=
+            [ ⟨"numTicks",  uintTy, Semantic.none, none, none, .qIn⟩
+            , ⟨"frameSize", uintTy, Semantic.none, none, none, .qIn⟩ ] } ]
+  , globals :=
+      [ ⟨"params",        .const "FramingCursorParams", Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"newSamples",    .roBuf uintTy,                Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"framesEmitted", .rwBuf uintTy,                Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"stateIO",       .rwBuf uintTy,                Semantic.none, some 3, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 1 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .ifNoElse (.bin "!=" (.member (.var "tid") "x") (.litUint 0))
+            [ .ret none ]
+        , .declInit uintTy "carry" (.index (.var "stateIO") (.litUint 0))
+        , .forCount "i" (.litUint 0) (.member (.var "params") "numTicks")
+            [ .declInit uintTy "total"
+                (.bin "+" (.var "carry") (.index (.var "newSamples") (.var "i")))
+            , .declInit uintTy "k"
+                (.bin "/" (.var "total") (.member (.var "params") "frameSize"))
+            , .assign (.index (.var "framesEmitted") (.var "i")) (.var "k")
+            , .assign (.var "carry")
+                (.bin "%" (.var "total") (.member (.var "params") "frameSize"))
+            ]
+        , .assign (.index (.var "stateIO") (.litUint 0)) (.var "carry")
+        ] }] }
+
+/-- Pinned reference emission. -/
+def expected : String :=
+"struct FramingCursorParams {
+  uint numTicks;
+  uint frameSize;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<FramingCursorParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> newSamples;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<uint> framesEmitted;
+[[vk::binding(3, 0)]]
+RWStructuredBuffer<uint> stateIO;
+
+[shader(\"compute\")] [numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  if ((tid.x != 0u)) {
+    return;
+  }
+  uint carry = stateIO[0u];
+  for (uint i = 0u; i < params.numTicks; ++i) {
+    uint total = (carry + newSamples[i]);
+    uint k = (total / params.frameSize);
+    framesEmitted[i] = k;
+    carry = (total % params.frameSize);
+  }
+  stateIO[0u] = carry;
+}"
+
+example : LeanSlang.emit shader = expected := by native_decide
+example : shader.entryPointName = "main" := by native_decide
+
+end Speech.SlangCodegen.FramingCursor

--- a/lean/Speech/SlangCodegen/JitterAppend.lean
+++ b/lean/Speech/SlangCodegen/JitterAppend.lean
@@ -1,0 +1,288 @@
+import LeanSlang
+
+/-!
+# `Speech.SlangCodegen.JitterAppend` — receive-side jitter-buffer evolution
+
+CHI-101 Phase A. Encodes the per-packet decision logic that runs in
+`Speech::on_received_audio_packet` (`speech.cpp:570+`): given the
+current jitter-buffer state and an incoming packet's sequence ID,
+decide
+
+  * how many invalid filler packets to push (gap fill),
+  * whether the new packet is a forward append (vs. an in-place
+    update of an out-of-order slot),
+  * which slot to update (for out-of-order),
+  * how many front entries to drop to keep `size <= maxSize`.
+
+## Why this kernel exists
+
+The C++ code path uses a signed `int64_t` `sequence_id_offset` to
+distinguish three sub-cases (forward / equal / out-of-order). The
+arithmetic is subtle: slot indices for out-of-order packets are
+computed as `bufferSize - 1 + offset` (a signed expression with
+`offset ≤ 0`), and the kernel exists to pin that down formally
+and catch any future drift the way `FramingCursor` caught F1.
+
+## Policy
+
+State carried across events via `stateIO`:
+
+  [0] currentSeq      uint  — last seen sequence ID for this peer
+  [1] currentSeqValid uint  — 0 if no packets seen yet, else 1
+  [2] currentSize     uint  — number of entries in the jitter buffer
+
+Per event with `incomingSeq[i]`:
+
+```
+if currentSeqValid == 0:
+    # First packet from this peer: behave as if currentSeq = incomingSeq - 1
+    # (matches speech.cpp:606-608). I.e. treat as forward-by-1.
+    fillerCount[i]    = 0
+    appendNew[i]      = 1
+    slotIsValid[i]    = 0
+    slotIdx[i]        = 0           # unused
+    sizeAfterAppend   = currentSize + 1
+    dropFromFront[i]  = max(0, sizeAfterAppend - maxSize)
+    newSize           = sizeAfterAppend - dropFromFront[i]
+    newCurrentSeq     = incomingSeq
+    newCurrentSeqValid = 1
+
+elif incomingSeq > currentSeq:                # forward
+    offset            = incomingSeq - currentSeq
+    fillerCount[i]    = offset - 1
+    appendNew[i]      = 1
+    slotIsValid[i]    = 0
+    slotIdx[i]        = 0           # unused
+    sizeAfterAppend   = currentSize + fillerCount[i] + 1
+    dropFromFront[i]  = max(0, sizeAfterAppend - maxSize)
+    newSize           = sizeAfterAppend - dropFromFront[i]
+    newCurrentSeq     = incomingSeq
+
+else:                                          # incomingSeq ≤ currentSeq (out-of-order / dup)
+    # signed-form slot = currentSize - 1 + (incomingSeq - currentSeq)
+    #                  = currentSize - 1 - (currentSeq - incomingSeq)
+    diff              = currentSeq - incomingSeq      # ≥ 0
+    fillerCount[i]    = 0
+    appendNew[i]      = 0
+    if currentSize >= 1 + diff:
+        slotIsValid[i] = 1
+        slotIdx[i]     = currentSize - 1 - diff
+    else:                                      # too old to repair
+        slotIsValid[i] = 0
+        slotIdx[i]     = 0
+    dropFromFront[i]  = 0
+    newSize           = currentSize
+    # currentSeq unchanged
+```
+
+The `else` branch matches the C++ for both `offset == 0` (duplicate)
+and `offset < 0` (out-of-order). When `offset == 0` and the buffer is
+non-empty, slot = `currentSize - 1` (the most-recent slot is
+overwritten). When the buffer is empty, slot is "invalid" and the
+duplicate is dropped silently. Both behaviors are faithful to
+`speech.cpp:642-654`.
+
+## Shape
+
+Sequential per-event state machine. Single-thread dispatch
+(`[numthreads(1, 1, 1)]`). Same idiom as `VadGate` and
+`FramingCursor`.
+
+## Bindings (set 0)
+
+  0  ConstantBuffer<JitterAppendParams> { uint numEvents; uint maxSize; }
+  1  StructuredBuffer<uint>    incomingSeq      length = numEvents
+  2  RWStructuredBuffer<uint>  fillerCount      length = numEvents
+  3  RWStructuredBuffer<uint>  appendNew        length = numEvents  (0 or 1)
+  4  RWStructuredBuffer<uint>  slotIsValid      length = numEvents  (0 or 1)
+  5  RWStructuredBuffer<uint>  slotIdx          length = numEvents
+  6  RWStructuredBuffer<uint>  dropFromFront    length = numEvents
+  7  RWStructuredBuffer<uint>  stateIO          length = 3
+-/
+
+namespace Speech.SlangCodegen.JitterAppend
+
+open LeanSlang
+
+private def uintTy : SlangType := .scalar .uint
+
+/-- Per-event jitter-buffer evolution kernel. Sequential single-thread. -/
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "JitterAppendParams"
+        , fields :=
+            [ ⟨"numEvents", uintTy, Semantic.none, none, none, .qIn⟩
+            , ⟨"maxSize",   uintTy, Semantic.none, none, none, .qIn⟩ ] } ]
+  , globals :=
+      [ ⟨"params",        .const "JitterAppendParams", Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"incomingSeq",   .roBuf uintTy,               Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"fillerCount",   .rwBuf uintTy,               Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"appendNew",     .rwBuf uintTy,               Semantic.none, some 3, some 0, .qIn⟩
+      , ⟨"slotIsValid",   .rwBuf uintTy,               Semantic.none, some 4, some 0, .qIn⟩
+      , ⟨"slotIdx",       .rwBuf uintTy,               Semantic.none, some 5, some 0, .qIn⟩
+      , ⟨"dropFromFront", .rwBuf uintTy,               Semantic.none, some 6, some 0, .qIn⟩
+      , ⟨"stateIO",       .rwBuf uintTy,               Semantic.none, some 7, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 1 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .ifNoElse (.bin "!=" (.member (.var "tid") "x") (.litUint 0))
+            [ .ret none ]
+        , .declInit uintTy "currentSeq"      (.index (.var "stateIO") (.litUint 0))
+        , .declInit uintTy "currentSeqValid" (.index (.var "stateIO") (.litUint 1))
+        , .declInit uintTy "currentSize"     (.index (.var "stateIO") (.litUint 2))
+        , .forCount "i" (.litUint 0) (.member (.var "params") "numEvents")
+            [ .declInit uintTy "seq" (.index (.var "incomingSeq") (.var "i"))
+
+            -- branch 1: first-packet path  (currentSeqValid == 0)
+            , .ifThen (.bin "==" (.var "currentSeqValid") (.litUint 0))
+                [ .assign (.index (.var "fillerCount")   (.var "i")) (.litUint 0)
+                , .assign (.index (.var "appendNew")     (.var "i")) (.litUint 1)
+                , .assign (.index (.var "slotIsValid")   (.var "i")) (.litUint 0)
+                , .assign (.index (.var "slotIdx")       (.var "i")) (.litUint 0)
+                , .declInit uintTy "sizeAfter"
+                    (.bin "+" (.var "currentSize") (.litUint 1))
+                , .declInit uintTy "drop"
+                    (.ternary (.bin ">" (.var "sizeAfter") (.member (.var "params") "maxSize"))
+                              (.bin "-" (.var "sizeAfter") (.member (.var "params") "maxSize"))
+                              (.litUint 0))
+                , .assign (.index (.var "dropFromFront") (.var "i")) (.var "drop")
+                , .assign (.var "currentSize")      (.bin "-" (.var "sizeAfter") (.var "drop"))
+                , .assign (.var "currentSeq")       (.var "seq")
+                , .assign (.var "currentSeqValid")  (.litUint 1)
+                ]
+
+                -- else: currentSeqValid == 1
+                [ .ifThen (.bin ">" (.var "seq") (.var "currentSeq"))
+                    -- branch 2: forward (seq > currentSeq)
+                    [ .declInit uintTy "offset"
+                        (.bin "-" (.var "seq") (.var "currentSeq"))
+                    , .declInit uintTy "filler"
+                        (.bin "-" (.var "offset") (.litUint 1))
+                    , .assign (.index (.var "fillerCount") (.var "i")) (.var "filler")
+                    , .assign (.index (.var "appendNew")   (.var "i")) (.litUint 1)
+                    , .assign (.index (.var "slotIsValid") (.var "i")) (.litUint 0)
+                    , .assign (.index (.var "slotIdx")     (.var "i")) (.litUint 0)
+                    , .declInit uintTy "sizeAfter"
+                        (.bin "+" (.bin "+" (.var "currentSize") (.var "filler")) (.litUint 1))
+                    , .declInit uintTy "drop"
+                        (.ternary (.bin ">" (.var "sizeAfter") (.member (.var "params") "maxSize"))
+                                  (.bin "-" (.var "sizeAfter") (.member (.var "params") "maxSize"))
+                                  (.litUint 0))
+                    , .assign (.index (.var "dropFromFront") (.var "i")) (.var "drop")
+                    , .assign (.var "currentSize") (.bin "-" (.var "sizeAfter") (.var "drop"))
+                    , .assign (.var "currentSeq")  (.var "seq")
+                    ]
+                    -- branch 3: out-of-order or duplicate (seq <= currentSeq)
+                    [ .declInit uintTy "diff"
+                        (.bin "-" (.var "currentSeq") (.var "seq"))
+                    , .assign (.index (.var "fillerCount")   (.var "i")) (.litUint 0)
+                    , .assign (.index (.var "appendNew")     (.var "i")) (.litUint 0)
+                    , .assign (.index (.var "dropFromFront") (.var "i")) (.litUint 0)
+                    , .ifThen
+                        (.bin ">=" (.var "currentSize")
+                                   (.bin "+" (.litUint 1) (.var "diff")))
+                        [ .assign (.index (.var "slotIsValid") (.var "i")) (.litUint 1)
+                        , .assign (.index (.var "slotIdx") (.var "i"))
+                            (.bin "-" (.bin "-" (.var "currentSize") (.litUint 1))
+                                      (.var "diff"))
+                        ]
+                        [ .assign (.index (.var "slotIsValid") (.var "i")) (.litUint 0)
+                        , .assign (.index (.var "slotIdx")     (.var "i")) (.litUint 0)
+                        ]
+                    ]
+                ]
+            ]
+        , .assign (.index (.var "stateIO") (.litUint 0)) (.var "currentSeq")
+        , .assign (.index (.var "stateIO") (.litUint 1)) (.var "currentSeqValid")
+        , .assign (.index (.var "stateIO") (.litUint 2)) (.var "currentSize")
+        ] }] }
+
+/-- Pinned reference emission. Drift in `LeanSlang.Emit` that affects
+    this output trips `native_decide` below. Regenerate after a deliberate
+    change via `lake exe emit_shaders /tmp/emit && cat /tmp/emit/jitter_append.slang`. -/
+def expected : String :=
+"struct JitterAppendParams {
+  uint numEvents;
+  uint maxSize;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<JitterAppendParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<uint> incomingSeq;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<uint> fillerCount;
+[[vk::binding(3, 0)]]
+RWStructuredBuffer<uint> appendNew;
+[[vk::binding(4, 0)]]
+RWStructuredBuffer<uint> slotIsValid;
+[[vk::binding(5, 0)]]
+RWStructuredBuffer<uint> slotIdx;
+[[vk::binding(6, 0)]]
+RWStructuredBuffer<uint> dropFromFront;
+[[vk::binding(7, 0)]]
+RWStructuredBuffer<uint> stateIO;
+
+[shader(\"compute\")] [numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  if ((tid.x != 0u)) {
+    return;
+  }
+  uint currentSeq = stateIO[0u];
+  uint currentSeqValid = stateIO[1u];
+  uint currentSize = stateIO[2u];
+  for (uint i = 0u; i < params.numEvents; ++i) {
+    uint seq = incomingSeq[i];
+    if ((currentSeqValid == 0u)) {
+      fillerCount[i] = 0u;
+      appendNew[i] = 1u;
+      slotIsValid[i] = 0u;
+      slotIdx[i] = 0u;
+      uint sizeAfter = (currentSize + 1u);
+      uint drop = ((sizeAfter > params.maxSize) ? (sizeAfter - params.maxSize) : 0u);
+      dropFromFront[i] = drop;
+      currentSize = (sizeAfter - drop);
+      currentSeq = seq;
+      currentSeqValid = 1u;
+    } else {
+      if ((seq > currentSeq)) {
+        uint offset = (seq - currentSeq);
+        uint filler = (offset - 1u);
+        fillerCount[i] = filler;
+        appendNew[i] = 1u;
+        slotIsValid[i] = 0u;
+        slotIdx[i] = 0u;
+        uint sizeAfter = ((currentSize + filler) + 1u);
+        uint drop = ((sizeAfter > params.maxSize) ? (sizeAfter - params.maxSize) : 0u);
+        dropFromFront[i] = drop;
+        currentSize = (sizeAfter - drop);
+        currentSeq = seq;
+      } else {
+        uint diff = (currentSeq - seq);
+        fillerCount[i] = 0u;
+        appendNew[i] = 0u;
+        dropFromFront[i] = 0u;
+        if ((currentSize >= (1u + diff))) {
+          slotIsValid[i] = 1u;
+          slotIdx[i] = ((currentSize - 1u) - diff);
+        } else {
+          slotIsValid[i] = 0u;
+          slotIdx[i] = 0u;
+        }
+      }
+    }
+  }
+  stateIO[0u] = currentSeq;
+  stateIO[1u] = currentSeqValid;
+  stateIO[2u] = currentSize;
+}"
+
+/-- The pretty-printer matches the pinned reference. -/
+example : LeanSlang.emit shader = expected := by native_decide
+
+/-- The kernel's entry-point name is `main`. -/
+example : shader.entryPointName = "main" := by native_decide
+
+end Speech.SlangCodegen.JitterAppend

--- a/lean/Speech/SlangCodegen/VadGate.lean
+++ b/lean/Speech/SlangCodegen/VadGate.lean
@@ -1,0 +1,197 @@
+import LeanSlang
+
+/-!
+# `Speech.SlangCodegen.VadGate` — hysteresis state machine for VAD output
+
+CHI-101 Phase A. Turns per-frame voice-activity scores (from the
+Silero classifier in godot-whisper, or any equivalent producer) into
+a gated boolean stream suitable for driving Opus-encode + WebTransport
+send.
+
+The classifier itself is upstream-pinned (libopus and Silero ML
+weights are not in scope). The gating *policy* on top — what counts
+as a voice frame given a score history — is what gets formalized here.
+
+## Policy
+
+Per-frame state machine, processed in order:
+
+  enterThreshold ∈ (0, 1)   e.g. 0.6 — score must exceed this to trip "on"
+  exitThreshold  ∈ (0, 1)   e.g. 0.4 — score must stay above this to keep alive
+  hangoverFrames ∈ ℕ        e.g. 8   — frames to hold "on" after score dips
+                                       (~80 ms at 10 ms/frame; prevents
+                                       chopping off final consonants)
+
+Hysteresis: `enterThreshold > exitThreshold` so transient dips don't
+flap the gate. Hangover prevents tail-cutoff at end of word.
+
+```
+state: { active: bool, hangover: uint }   // initially {false, 0}
+
+per frame i with score[i]:
+  if !active:
+    if score[i] > enterThreshold:
+      active   = true
+      hangover = hangoverFrames
+  else:  // active
+    if score[i] > exitThreshold:
+      hangover = hangoverFrames           // refresh
+    elif hangover > 0:
+      hangover = hangover - 1
+    else:
+      active = false
+
+  gated[i] = active
+```
+
+## Shape
+
+Inherently sequential — each frame's decision depends on the previous
+frame's state. The kernel runs as a single-thread dispatch
+(`[numthreads(1, 1, 1)]`, one group) that walks `numFrames` in order.
+This is consistent with how cloth_dynamics handles small-scale
+sequential logic (`dot_reduce_serial`).
+
+For the godot-speech audio thread we'd dispatch this once per
+captured batch of frames (typically 1 frame at 100 Hz, but the
+kernel handles N≥1 uniformly so it's drop-in for batched offline
+verification against recorded clips too).
+
+## Bindings (set 0)
+
+  0  ConstantBuffer<VadGateParams> {
+       uint numFrames;
+       float enterThreshold;
+       float exitThreshold;
+       uint hangoverFrames;
+     }
+  1  StructuredBuffer<float>   score      length = numFrames
+  2  RWStructuredBuffer<uint>  gated      length = numFrames    (0 or 1)
+  3  RWStructuredBuffer<uint>  stateIO    length = 2
+       // [0] = active (0 or 1) carried across dispatches
+       // [1] = hangover remaining (0..hangoverFrames)
+
+State carry-over via `stateIO` lets the gate run across arbitrarily
+many small dispatches without resetting at every audio-thread tick.
+
+The pinned reference text below is asserted by `native_decide`. To
+regenerate after a deliberate change, run
+`lake exe emit_shaders /tmp/emit && cat /tmp/emit/vad_gate.slang`
+and replace `expected` with the new output.
+-/
+
+namespace Speech.SlangCodegen.VadGate
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+
+/-- VAD gate hysteresis kernel. Single-thread dispatch walks frames
+    in order so the per-frame state dependency is honored without an
+    inter-thread sync. -/
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "VadGateParams"
+        , fields :=
+            [ ⟨"numFrames",      uintTy,  Semantic.none, none, none, .qIn⟩
+            , ⟨"enterThreshold", floatTy, Semantic.none, none, none, .qIn⟩
+            , ⟨"exitThreshold",  floatTy, Semantic.none, none, none, .qIn⟩
+            , ⟨"hangoverFrames", uintTy,  Semantic.none, none, none, .qIn⟩ ] } ]
+  , globals :=
+      [ ⟨"params",  .const "VadGateParams",  Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"score",   .roBuf floatTy,          Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"gated",   .rwBuf uintTy,           Semantic.none, some 2, some 0, .qIn⟩
+      , ⟨"stateIO", .rwBuf uintTy,           Semantic.none, some 3, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 1 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .ifNoElse (.bin "!=" (.member (.var "tid") "x") (.litUint 0))
+            [ .ret none ]
+        , .declInit uintTy "active"   (.index (.var "stateIO") (.litUint 0))
+        , .declInit uintTy "hangover" (.index (.var "stateIO") (.litUint 1))
+        , .forCount "i" (.litUint 0) (.member (.var "params") "numFrames")
+            [ .declInit floatTy "s" (.index (.var "score") (.var "i"))
+            , .ifThen (.bin "==" (.var "active") (.litUint 0))
+                [ .ifNoElse
+                    (.bin ">" (.var "s") (.member (.var "params") "enterThreshold"))
+                    [ .assign (.var "active")   (.litUint 1)
+                    , .assign (.var "hangover")
+                        (.member (.var "params") "hangoverFrames") ]
+                ]
+                [ .ifThen
+                    (.bin ">" (.var "s") (.member (.var "params") "exitThreshold"))
+                    [ .assign (.var "hangover")
+                        (.member (.var "params") "hangoverFrames") ]
+                    [ .ifThen (.bin ">" (.var "hangover") (.litUint 0))
+                        [ .assign (.var "hangover")
+                            (.bin "-" (.var "hangover") (.litUint 1)) ]
+                        [ .assign (.var "active") (.litUint 0) ]
+                    ]
+                ]
+            , .assign (.index (.var "gated") (.var "i")) (.var "active")
+            ]
+        , .assign (.index (.var "stateIO") (.litUint 0)) (.var "active")
+        , .assign (.index (.var "stateIO") (.litUint 1)) (.var "hangover")
+        ] }] }
+
+/-- Pinned reference emission. Drift in `LeanSlang.Emit` that affects
+    this output trips `native_decide` below. Update both this string and
+    the kernel in lockstep. -/
+def expected : String :=
+"struct VadGateParams {
+  uint numFrames;
+  float enterThreshold;
+  float exitThreshold;
+  uint hangoverFrames;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<VadGateParams> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> score;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<uint> gated;
+[[vk::binding(3, 0)]]
+RWStructuredBuffer<uint> stateIO;
+
+[shader(\"compute\")] [numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  if ((tid.x != 0u)) {
+    return;
+  }
+  uint active = stateIO[0u];
+  uint hangover = stateIO[1u];
+  for (uint i = 0u; i < params.numFrames; ++i) {
+    float s = score[i];
+    if ((active == 0u)) {
+      if ((s > params.enterThreshold)) {
+        active = 1u;
+        hangover = params.hangoverFrames;
+      }
+    } else {
+      if ((s > params.exitThreshold)) {
+        hangover = params.hangoverFrames;
+      } else {
+        if ((hangover > 0u)) {
+          hangover = (hangover - 1u);
+        } else {
+          active = 0u;
+        }
+      }
+    }
+    gated[i] = active;
+  }
+  stateIO[0u] = active;
+  stateIO[1u] = hangover;
+}"
+
+/-- The pretty-printer matches the pinned reference. -/
+example : LeanSlang.emit shader = expected := by native_decide
+
+/-- The kernel's entry-point name is `main`. -/
+example : shader.entryPointName = "main" := by native_decide
+
+end Speech.SlangCodegen.VadGate

--- a/lean/lake-manifest.json
+++ b/lean/lake-manifest.json
@@ -1,0 +1,15 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"url": "https://github.com/V-Sekai-fire/lean-slang.git",
+   "type": "git",
+   "subDir": null,
+   "scope": "",
+   "rev": "813d6c62b298bcd3f7177264179a7e1d16bd87cd",
+   "name": "LeanSlang",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "v0.0.5",
+   "inherited": false,
+   "configFile": "lakefile.toml"}],
+ "name": "Speech",
+ "lakeDir": ".lake"}

--- a/lean/lakefile.lean
+++ b/lean/lakefile.lean
@@ -1,0 +1,12 @@
+import Lake
+open Lake DSL
+
+package Speech where
+
+require LeanSlang from git
+  "https://github.com/V-Sekai-fire/lean-slang.git" @ "v0.0.5"
+
+@[default_target] lean_lib Speech where
+
+lean_exe emit_shaders where
+  root := `EmitShaders

--- a/lean/lean-toolchain
+++ b/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.29.1

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -169,6 +169,25 @@ Phase A step 4b (apply-the-diff pass) and tracked separately — this doc only
 records the diagnosis. The kernel + validator stay in tree as a regression
 guard.
 
+**Corroborating evidence:** `speech_processor.cpp:401` (the analogous loop
+inside `test_process_mono_audio_frames`, the test-only entry point) already
+uses the safe form:
+
+```cpp
+while (current_offset + SPEECH_SETTING_BUFFER_FRAME_COUNT <= resampled_frame_count) {
+```
+
+i.e. the codebase had *already diverged*: someone wrote the safe form for the
+test path but did not propagate the fix back to `_mix_audio`. The existing
+test suite (`tests/test_speech_processor.h::Test Direct Audio Processing via
+test_process_mono_audio_frames`) exercises *only* the test path, so it would
+have continued reporting green forever without catching F1.
+
+**Fix applied:** see the diff that landed alongside this doc update —
+`_mix_audio` now uses the integer-divmod form, matching both the kernel and
+the previously-divergent test path. The `framing_cursor` validator stays in
+tree as a regression guard.
+
 **Status of the historical-stickiness hypothesis:** this is *one* of the things
 that was wrong on the speech path. Not necessarily the whole story. Phase A
 continues by formalizing the next layer (jitter buffer / decode-side cursor)

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -11,12 +11,13 @@ methodology, and outstanding questions; it will be the artifact CHI-101 Step 6 e
 | 1    | `lean/` subdirectory mirroring `TOOL_cloth_dynamics`| done         |
 | 2    | Lean spec: VAD gating policy                        | done (1st kernel) |
 | 2    | Lean spec: frame energy (VAD fallback signal)       | done         |
-| 2    | Lean spec: PCM framing / resampling                 | not started  |
+| 2    | Lean spec: framing cursor (capture-loop policy)     | done         |
+| 2    | Lean spec: PCM framing / resampling (full)          | partial      |
 | 2    | Lean spec: jitter buffer arithmetic                 | not started  |
 | 2    | Lean spec: Opus encode/decode invariants            | not started  |
 | 3    | Dual-target codegen (slangc-cpp + slangc-metal)     | done (both pass) |
-| 3    | `tests/slang_validate/` bit-exact CPU validators    | done (2 kernels, green) |
-| 4    | Diff `speech_processor.cpp` against Lean reference  | not started  |
+| 3    | `tests/slang_validate/` bit-exact CPU validators    | done (3 kernels, green) |
+| 4    | Diff `speech_processor.cpp` against Lean reference  | **1st finding landed** |
 | 5    | End-to-end VAD-gate test on recorded clips          | not started  |
 | 6    | 30-min Win/macOS/Linux audio-thread soak            | not started  |
 
@@ -104,31 +105,90 @@ Three orthogonal checks per kernel, all required to pass:
    produce a `.metallib` artifact. Never dispatched at runtime; failure
    here means the spec leaked a CPU-specific assumption.
 
-## Open questions for Phase A
+## Findings (Phase A step 4)
 
-### Q1. Where does the existing `speech_processor` divergence live?
+### F1. `speech_processor.cpp:130` — unsigned-underflow + off-by-one in the framing loop
 
-The CHI-101 issue notes "past V-Sekai voice attempts got stuck on the speech
-side". Phase A step 4 is to diff each Lean-specified kernel against the C++
-code path in `speech_processor.cpp` / `speech.cpp` / `speech_decoder.cpp` and
-find where they disagree.
+**Status:** confirmed by `tests/slang_validate/framing_cursor_test.cpp`.
+Five concrete diff cases between the Lean spec (`FramingCursor`) and the
+literal C++ loop.
 
-Hypotheses worth ruling out first:
+**Location:** `speech_processor.cpp:130`, inside `SpeechProcessor::_mix_audio`:
 
-* **Resampler offset accounting.** `speech_processor.cpp` runs libsamplerate
-  with a manual offset increment after each `_resample_audio_buffer` call. If
-  the increment formula doesn't match libsamplerate's internal frame consumption,
-  capture drift accumulates over minutes.
+```cpp
+while (capture_real_array_offset
+       < resampled_frame_count - SPEECH_SETTING_BUFFER_FRAME_COUNT) {
+  // emit one 480-sample packet
+  capture_real_array_offset += SPEECH_SETTING_BUFFER_FRAME_COUNT;
+}
+```
+
+**Two distinct defects in one line:**
+
+1. **Unsigned underflow.** `resampled_frame_count` and `SPEECH_SETTING_BUFFER_FRAME_COUNT`
+   are both `uint32_t`. When `resampled_frame_count < 480` — which can happen on
+   the very first audio-thread tick, or on a tick where `_resample_audio_buffer`
+   returns 0 from libsamplerate due to insufficient input — the subtraction wraps
+   to ~4 G and the loop reads way past `capture_real_array.size() = 8192`.
+   The validator caps iterations at 1 M so we can report the bug without hanging
+   CI; in production this would have been an out-of-bounds read until the AV
+   subsystem crashed or the audio thread starved.
+2. **Off-by-one at the boundary.** Even in the safe range, strict `<` rather than
+   `<=` mis-fires whenever `resampled_frame_count - capture_real_array_offset`
+   equals exactly `frameSize`. Validator demonstrates kernel=1, buggy=0 for
+   the `0 + 480` and `240 + 240` cases. Under happy-path 48 kHz capture with
+   `RECORD_MIX_FRAMES = 2048` this boundary rarely lines up — explaining why
+   the bug went undetected through manual testing — but every exact-multiple
+   tick is silently one frame light.
+
+**Validator output:**
+
+```
+framing_cursor diff against speech_processor.cpp:130 loop:
+  underflow: 0+100             kernel=0  buggy=1000001(FUSE-CAPPED)  expected=0  DIFF
+  underflow: 50+0              kernel=0  buggy=1000001(FUSE-CAPPED)  expected=0  DIFF
+  off-by-one: 0+480            kernel=1  buggy=0  expected=1  DIFF
+  off-by-one: 240+240          kernel=1  buggy=0  expected=1  DIFF
+  happy: 0+960                 kernel=2  buggy=1  expected=2  DIFF
+```
+
+**Recommended fix:** replace the loop with explicit integer divmod, mirroring
+the kernel:
+
+```cpp
+const uint32_t total = capture_real_array_offset + resampler_output_count;
+const uint32_t frames_to_emit = total / SPEECH_SETTING_BUFFER_FRAME_COUNT;
+for (uint32_t f = 0; f < frames_to_emit; ++f) {
+  // emit one 480-sample packet starting at capture_real_array + f * 480
+}
+capture_real_array_offset = total % SPEECH_SETTING_BUFFER_FRAME_COUNT;
+```
+
+That's exactly the policy `FramingCursor.lean` encodes. The fix is deferred to
+Phase A step 4b (apply-the-diff pass) and tracked separately — this doc only
+records the diagnosis. The kernel + validator stay in tree as a regression
+guard.
+
+**Status of the historical-stickiness hypothesis:** this is *one* of the things
+that was wrong on the speech path. Not necessarily the whole story. Phase A
+continues by formalizing the next layer (jitter buffer / decode-side cursor)
+and diffing those.
+
+## Other hypotheses still open
+
 * **Capture ring-buffer accounting.** `capture_discarded_frames` /
   `capture_pushed_frames` / `capture_ring_current_size` — if any of these are
   updated in the wrong order under audio-thread contention, frames get
-  silently dropped.
+  silently dropped. Not yet formalized.
 * **Opus 10 ms vs 20 ms frame mismatch.** `SPEECH_SETTING_MILLISECONDS_PER_PACKET
   = 10` and `OPUS_APPLICATION_VOIP` — verify libopus is configured for 10 ms
   frame size everywhere; one place defaulting to 20 ms would corrupt every
-  packet.
-
-None of these are confirmed yet — listing as candidates for the diff pass.
+  packet. Not yet formalized.
+* **`RESAMPLED_BUFFER_FACTOR = sizeof(int)`** in `speech_processor.cpp:44` —
+  using `sizeof(int)` as a buffer-size multiplier is a code smell of a
+  refactor-gone-wrong. It happens to be `4` on every target platform, so the
+  buffer is correctly oversized for 4× upsampling, but the *intent* is opaque.
+  Worth a follow-up rename even if not load-bearing.
 
 ### Q2. VAD policy parameters — what defaults?
 

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -12,12 +12,12 @@ methodology, and outstanding questions; it will be the artifact CHI-101 Step 6 e
 | 2    | Lean spec: VAD gating policy                        | done (1st kernel) |
 | 2    | Lean spec: frame energy (VAD fallback signal)       | done         |
 | 2    | Lean spec: framing cursor (capture-loop policy)     | done         |
+| 2    | Lean spec: jitter-buffer append (receive-side)      | done         |
 | 2    | Lean spec: PCM framing / resampling (full)          | partial      |
-| 2    | Lean spec: jitter buffer arithmetic                 | not started  |
 | 2    | Lean spec: Opus encode/decode invariants            | not started  |
 | 3    | Dual-target codegen (slangc-cpp + slangc-metal)     | done (both pass) |
-| 3    | `tests/slang_validate/` bit-exact CPU validators    | done (3 kernels, green) |
-| 4    | Diff `speech_processor.cpp` against Lean reference  | **1st finding landed** |
+| 3    | `tests/slang_validate/` bit-exact CPU validators    | done (4 kernels, green) |
+| 4    | Diff `speech_processor.cpp` against Lean reference  | **F1 landed + fixed; F2 noted** |
 | 5    | End-to-end VAD-gate test on recorded clips          | not started  |
 | 6    | 30-min Win/macOS/Linux audio-thread soak            | not started  |
 
@@ -192,6 +192,44 @@ tree as a regression guard.
 that was wrong on the speech path. Not necessarily the whole story. Phase A
 continues by formalizing the next layer (jitter buffer / decode-side cursor)
 and diffing those.
+
+### F2. `JITTER_BUFFER_SPEEDUP` / `JITTER_BUFFER_SLOWDOWN` are dead settings
+
+**Status:** confirmed by `grep` over `speech.cpp` + `speech.h`. The fields
+exist, the getters/setters are bound, and `ADD_PROPERTY` exposes them to the
+editor. But **nothing reads them in any decision-logic code path**.
+
+```
+$ grep -n 'JITTER_BUFFER_SPEEDUP\|JITTER_BUFFER_SLOWDOWN' speech.cpp speech.h
+speech.h:93:    int JITTER_BUFFER_SPEEDUP = 12;
+speech.h:94:    int JITTER_BUFFER_SLOWDOWN = 6;
+speech.cpp:114-128: getters/setters only
+speech.cpp:307-321: ClassDB / ADD_PROPERTY only
+```
+
+The accompanying playback-rate fields `STREAM_STANDARD_PITCH` and
+`STREAM_SPEEDUP_PITCH` are also exposed but the playback code path doesn't
+read either — it always pushes packets at the default rate.
+
+**Implication:** either an adaptive playback-rate scheme was planned and the
+detection-side code never landed, or it was ripped out and the configuration
+surface was left behind. Either way, scripts setting these properties expect
+behavior the engine doesn't actually provide.
+
+**Recommendation:** fold into Phase B step 11 (push-to-talk + open-mic
+toggles). The jitter-buffer adaptive speed is a natural addition to the
+network-transport story and the Lean spec is straightforward (compare
+`currentSize` against thresholds; emit a per-tick rate-adjustment factor).
+Until then, mark these properties `@deprecated` or remove them to avoid
+silent misconfiguration.
+
+**Status of the JitterAppend kernel for F-finding:** the `JitterAppend`
+validator runs all eight oracle cases (first-packet, in-order, gap,
+overflow-maxSize, duplicate, out-of-order in-range, out-of-order too-old,
+forward-by-1) and the kernel matches both the CPU reference and the
+hand-checked oracle frame-for-frame. The `on_received_audio_packet` math
+in `speech.cpp` is *correct* — it doesn't have an F1-style bug. The kernel
+stays in tree as a regression guard for any future edits to the receive path.
 
 ## Other hypotheses still open
 

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -1,0 +1,181 @@
+# 2026-05-12 — Speech isolation under Lean → LeanSlang verification
+
+**CHI-101 Phase A** — formalize the godot-speech kernels and the VAD-gating policy in
+isolation, before any multiplayer-fabric integration. This doc tracks Phase A status,
+methodology, and outstanding questions; it will be the artifact CHI-101 Step 6 expects.
+
+## Status
+
+| Step | Item                                                | State        |
+|------|-----------------------------------------------------|--------------|
+| 1    | `lean/` subdirectory mirroring `TOOL_cloth_dynamics`| done         |
+| 2    | Lean spec: VAD gating policy                        | done (1st kernel) |
+| 2    | Lean spec: frame energy (VAD fallback signal)       | done         |
+| 2    | Lean spec: PCM framing / resampling                 | not started  |
+| 2    | Lean spec: jitter buffer arithmetic                 | not started  |
+| 2    | Lean spec: Opus encode/decode invariants            | not started  |
+| 3    | Dual-target codegen (slangc-cpp + slangc-metal)     | done (both pass) |
+| 3    | `tests/slang_validate/` bit-exact CPU validators    | done (2 kernels, green) |
+| 4    | Diff `speech_processor.cpp` against Lean reference  | not started  |
+| 5    | End-to-end VAD-gate test on recorded clips          | not started  |
+| 6    | 30-min Win/macOS/Linux audio-thread soak            | not started  |
+
+Phase B (multiplayer-fabric / WebTransport / Steam Audio integration) is gated on
+Phase A producing a clean `speech_processor`/Lean diff or a documented fallback
+decision.
+
+## Methodology — what we're copying from `TOOL_cloth_dynamics`
+
+The cloth-dynamics work proved the **Lean → LeanSlang DSL → slangc-cpp bit-exact
+validator** pattern on the PR-G AVBD adjoint chain: a 1068× drift at step 1, masked
+for weeks by visual eyeballing of the simulation, surfaced immediately once the
+forward and backward kernels were re-derived in Lean and the analytic adjoint was
+finite-difference-checked against the forward emit. Reference:
+`/Users/ernest.lee/Desktop/TOOL_cloth_dynamics/lean/Cloth/SlangCodegen/`.
+
+The pattern, applied here:
+
+1. **Each deterministic V-Sekai-side kernel** (one per `Speech.SlangCodegen.*`
+   module) is written as a `LeanSlang.SlangShaderModule` AST.
+2. **A pinned `expected : String`** holds the exact emit output. `native_decide`
+   proves `LeanSlang.emit shader = expected` at Lean build time. Any drift in
+   either the kernel or the LeanSlang pretty-printer trips compilation.
+3. **`lake exe emit_shaders <dir>`** writes every `.slang` file to disk for the
+   downstream slangc pipeline.
+4. **`tests/slang_validate/Makefile`** runs each emitted `.slang` through
+   `slangc -target cpp` to get a CPU function, links it with a hand-written
+   `<kernel>_test.cpp` harness that populates inputs from a known fixture and
+   asserts the output matches an **independent CPU reference**.
+5. **Both `slangc-cpp` and `slangc-metal` targets must build clean** for every
+   kernel. We don't run audio on the GPU, but the Metal build is a free
+   second-pair-of-eyes on spec portability: anything that depends on a
+   CPU-specific assumption (alignment, intrinsic name, addrspace) won't survive
+   translation to a compute shader.
+
+Upstream-pinned components sit **outside** this dual-target boundary:
+
+* `thirdparty/opus/` — libopus internals (NSQ, CELT, SILK encoders): treated as
+  a black box. We formalize the **wrapper arithmetic** (frame-size
+  bookkeeping, packet-size bounds) but not the codec's internals.
+* `thirdparty/libsamplerate/` — same treatment: wrapper arithmetic only.
+* Silero VAD ML weights (via `godot-whisper`) — black box producer of per-frame
+  scores; only the gating policy on top is formalized.
+* whisper.cpp transcription path — disabled at runtime, never crosses the Lean
+  boundary.
+
+## What's in `lean/` today
+
+```
+lean/
+├── lakefile.lean                          # require LeanSlang v0.0.5
+├── lean-toolchain                         # leanprover/lean4:v4.29.1
+├── Speech.lean                            # top-level lib (imports SlangCodegen)
+├── Speech/SlangCodegen.lean               # umbrella module
+├── Speech/SlangCodegen/FrameEnergy.lean   # per-frame Σ x² (energy-VAD fallback)
+├── Speech/SlangCodegen/VadGate.lean       # hysteresis state machine
+└── EmitShaders.lean                       # `lake exe emit_shaders <dir>`
+```
+
+`lake build Speech` and `lake build emit_shaders` both succeed clean as of this
+doc's date. Both bit-exact `native_decide` pins pass.
+
+`make -C tests/slang_validate test` (with `SLANGC` pointed at a slangc 2026.8+
+install — cloth_dynamics' `bin/slangc` works directly) is also green end-to-end:
+
+```
+frame_energy: 3/3 frames OK (max_abs_diff=0, 0.0ms)
+vad_gate: 20/20 frames OK (one-shot, ref, oracle, split, all match; 0.0ms)
+all kernels OK (cpp target)
+all kernels OK (metal target — discipline build)
+```
+
+Three orthogonal checks per kernel, all required to pass:
+
+1. **Lean `native_decide`** — `LeanSlang.emit shader = expected` proved at
+   Lean build time. Catches any drift in either the kernel AST or the
+   LeanSlang pretty-printer.
+2. **slangc-cpp bit-exact harness** — slangc compiles the emitted `.slang`
+   to a C++ function; a hand-written `<kernel>_test.cpp` runs it on a known
+   input and compares against an in-order CPU reference for 0-ULP bit
+   equality. For `vad_gate`, also checks against a hand-checked oracle and
+   against a split-dispatch state-carry-over run.
+3. **slangc-metal discipline build** — slangc compiles the same `.slang`
+   to a Metal compute shader and Apple's `xcrun metal` + `xcrun metallib`
+   produce a `.metallib` artifact. Never dispatched at runtime; failure
+   here means the spec leaked a CPU-specific assumption.
+
+## Open questions for Phase A
+
+### Q1. Where does the existing `speech_processor` divergence live?
+
+The CHI-101 issue notes "past V-Sekai voice attempts got stuck on the speech
+side". Phase A step 4 is to diff each Lean-specified kernel against the C++
+code path in `speech_processor.cpp` / `speech.cpp` / `speech_decoder.cpp` and
+find where they disagree.
+
+Hypotheses worth ruling out first:
+
+* **Resampler offset accounting.** `speech_processor.cpp` runs libsamplerate
+  with a manual offset increment after each `_resample_audio_buffer` call. If
+  the increment formula doesn't match libsamplerate's internal frame consumption,
+  capture drift accumulates over minutes.
+* **Capture ring-buffer accounting.** `capture_discarded_frames` /
+  `capture_pushed_frames` / `capture_ring_current_size` — if any of these are
+  updated in the wrong order under audio-thread contention, frames get
+  silently dropped.
+* **Opus 10 ms vs 20 ms frame mismatch.** `SPEECH_SETTING_MILLISECONDS_PER_PACKET
+  = 10` and `OPUS_APPLICATION_VOIP` — verify libopus is configured for 10 ms
+  frame size everywhere; one place defaulting to 20 ms would corrupt every
+  packet.
+
+None of these are confirmed yet — listing as candidates for the diff pass.
+
+### Q2. VAD policy parameters — what defaults?
+
+The `VadGate` Lean spec parameterizes:
+
+* `enterThreshold` — score above this trips "on". Default candidate: **0.6**.
+* `exitThreshold` — score above this refreshes hangover. Default candidate:
+  **0.4** (well below enter, so transients don't flap).
+* `hangoverFrames` — frames to hold "on" after a dip. Default candidate:
+  **8 frames = 80 ms** at 10 ms/frame. WebRTC's open-mic VAD uses ~100 ms in
+  most reference configs; 80 ms is on the snappier end and avoids cutting off
+  the tail of soft consonants without holding the gate open through
+  multi-second pauses.
+
+These should be **validated against recorded clips** in Phase A step 5 before
+being baked in as runtime constants.
+
+### Q3. Where does the VAD score actually come from?
+
+The CHI-101 plan uses Silero from `godot-whisper`. Open follow-up: pick the
+GDExtension API surface that returns per-frame scores (whisper.cpp's bundled
+Silero exposes a `vad_segments` query; we want the raw per-frame probability,
+not the segment-merged output, so we can run our own hysteresis on top).
+
+Worst case: vendor the Silero ONNX session into godot-speech directly so we
+don't have to wait on a godot-whisper API change.
+
+### Q4. Should we add an `EnergyVadFallback` kernel?
+
+If the Silero integration slips, an energy-floor-based VAD is a poor-but-fast
+fallback. The `FrameEnergy` kernel already produces the input; a second kernel
+that adapts a noise floor and gates on `energy[f] > k · floor` would be a few
+lines on top. Decision deferred until Phase A step 3 outcomes are clear.
+
+## If Phase A fails
+
+Per the CHI-101 issue: drop godot-speech, use stock Godot `AudioEffectCapture`
+plus a userland libopus GDExtension. If that's still shaky, voice falls back to
+Stage 1 and Stage 0 ships as multi-user dots only.
+
+The decision lives **here** in this doc — at the bottom of Phase A — once the
+diff-against-spec pass is complete.
+
+## Pointers
+
+* CHI-101 issue: <https://linear.app/chibifire/issue/CHI-101>
+* Methodology reference: `/Users/ernest.lee/Desktop/TOOL_cloth_dynamics/lean/Cloth/SlangCodegen/`
+* Pinned-emit pattern: `Cloth/SlangCodegen/SpringProject.lean` (smallest readable example)
+* Multi-branch pattern: `Cloth/SlangCodegen/SelfCollisionScan.lean` (`.ifThen`, `.forCount`)
+* Validator harness reference: `TOOL_cloth_dynamics/tests/slang_validate/spring_project_test.cpp`

--- a/speech_processor.cpp
+++ b/speech_processor.cpp
@@ -127,7 +127,13 @@ void SpeechProcessor::_mix_audio(const Vector2 *p_capture_buffer) {
 								static_cast<size_t>(capture_real_array_offset));
 		capture_real_array_offset = 0;
 		const float *capture_real_array_read_ptr = capture_real_array.ptr();
-		while (capture_real_array_offset < resampled_frame_count - SPEECH_SETTING_BUFFER_FRAME_COUNT) {
+		// Integer-divmod framing — see lean/Speech/SlangCodegen/FramingCursor.lean
+		// and manuals/decisions/2026-05-12-speech-isolation.md (F1) for the prior
+		// `offset < count - frameSize` form, which underflowed on resampler
+		// return = 0 and silently dropped a frame on exact-multiple boundaries.
+		const uint32_t frames_to_emit =
+				resampled_frame_count / SPEECH_SETTING_BUFFER_FRAME_COUNT;
+		for (uint32_t f = 0; f < frames_to_emit; ++f) {
 			for (int64_t i = 0; i < SPEECH_SETTING_BUFFER_FRAME_COUNT; i++) {
 				float frame_float = capture_real_array_read_ptr[static_cast<size_t>(capture_real_array_offset) + i];
 				int16_t val = static_cast<int16_t>(CLAMP(frame_float * 32767.0f, -32768.0f, 32767.0f));

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -36,10 +36,11 @@ INCLUDES   := -I$(SLANG_INC) -I$(EMITTED)
 # Per-test-to-kernel mapping. test_name → kernel_name.
 TESTS      := frame_energy:frame_energy \
               framing_cursor:framing_cursor \
+              jitter_append:jitter_append \
               vad_gate:vad_gate
 
 # Metal kernels (discipline build; never run at runtime).
-METAL_KERNELS := frame_energy framing_cursor vad_gate
+METAL_KERNELS := frame_energy framing_cursor jitter_append vad_gate
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -34,10 +34,12 @@ CXXFLAGS   ?= -std=c++17 -O2 -Wall -Wextra -Wno-unused-parameter
 INCLUDES   := -I$(SLANG_INC) -I$(EMITTED)
 
 # Per-test-to-kernel mapping. test_name → kernel_name.
-TESTS      := frame_energy:frame_energy vad_gate:vad_gate
+TESTS      := frame_energy:frame_energy \
+              framing_cursor:framing_cursor \
+              vad_gate:vad_gate
 
 # Metal kernels (discipline build; never run at runtime).
-METAL_KERNELS := frame_energy vad_gate
+METAL_KERNELS := frame_energy framing_cursor vad_gate
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -1,0 +1,100 @@
+# Real-input validators for the Speech.SlangCodegen.* kernels.
+#
+# Each kernel is converted by `slangc -target cpp` to a CPU function
+# `main_0(varyingInput, params, globals)`, then compiled together with
+# a hand-written test harness that:
+#   1. populates the kernel's input buffers with known values,
+#   2. invokes the kernel as a single dispatch,
+#   3. asserts the output matches an independent CPU reference.
+#
+# `make test` runs every harness; non-zero exit on any failure.
+#
+# Discipline target: each kernel also builds through `slangc -target
+# metal` to surface CPU-specific spec leaks (e.g. addrspace, intrinsic
+# names). Audio never runs on the GPU at runtime — the Metal build is
+# a free portability check. See CHI-101 issue / 2026-05-12 decision doc.
+#
+# Prerequisite: a slangc toolchain. Point $SLANGC at it, e.g.:
+#   export SLANGC=$(realpath ../TOOL_cloth_dynamics/bin/slangc)
+# Cloth-dynamics' bin/slangc (slangc 2026.8+) works directly. If you
+# don't have one, run TOOL_cloth_dynamics/misc/install-slang.sh which
+# downloads a known-good release into bin/.slang/.
+
+REPO_ROOT  := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+SLANGC     ?= slangc
+EMITTED    := $(CURDIR)/build
+LEAN_DIR   := $(REPO_ROOT)/lean
+SLANG_INC  := $(abspath $(dir $(SLANGC))/../include)
+
+CXX        ?= clang++
+# -Wno-unused-parameter silences clang's complaint about
+# `entryPointParams_0` in slangc -target cpp output (the parameter is
+# part of the Slang ABI and unused by every compute kernel we emit).
+CXXFLAGS   ?= -std=c++17 -O2 -Wall -Wextra -Wno-unused-parameter
+INCLUDES   := -I$(SLANG_INC) -I$(EMITTED)
+
+# Per-test-to-kernel mapping. test_name → kernel_name.
+TESTS      := frame_energy:frame_energy vad_gate:vad_gate
+
+# Metal kernels (discipline build; never run at runtime).
+METAL_KERNELS := frame_energy vad_gate
+METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
+
+TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
+KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))
+
+KERNELS    := $(sort $(foreach t,$(TESTS),$(word 2,$(subst :, ,$(t)))))
+SHADERS    := $(addprefix $(EMITTED)/,$(addsuffix _emit.cpp,$(KERNELS)))
+BINS       := $(addprefix $(EMITTED)/,$(addsuffix _test,$(TEST_NAMES)))
+
+.PHONY: test test-cpp test-metal clean emit-shaders metal-discipline
+
+# Default target: cpp-target bit-exact tests + Metal-target discipline build.
+# `test-metal` is a no-op on Linux (xcrun missing); CI gates it on host OS.
+test: test-cpp metal-discipline
+
+test-cpp: $(BINS)
+	@fails=0; \
+	for b in $(BINS); do \
+	  echo "=== $$b"; $$b || fails=$$(( fails + 1 )); \
+	done; \
+	if [ $$fails -ne 0 ]; then echo "FAILED: $$fails"; exit 1; fi; \
+	echo "all kernels OK (cpp target)"
+
+# Metal discipline: every kernel must reach .metallib without error.
+# We don't dispatch them at runtime.
+metal-discipline: $(METALLIBS)
+	@echo "all kernels OK (metal target — discipline build)"
+
+# Make sure the .slang files exist before we ask slangc for cpp output.
+emit-shaders:
+	@cd $(LEAN_DIR) && lake exe emit_shaders /tmp/godot_speech_emit >/dev/null
+
+# slang → cpp source.
+$(EMITTED)/%_emit.cpp: emit-shaders
+	@mkdir -p $(EMITTED)
+	$(SLANGC) -target cpp -stage compute -entry main \
+	  -o $@ /tmp/godot_speech_emit/$*.slang
+
+# Per-test build rule. Each test_name maps to a kernel_name via the
+# TESTS list; the test source #include's its kernel's emit.
+.SECONDEXPANSION:
+$(EMITTED)/%_test: %_test.cpp $$(EMITTED)/$$(call KERNEL_FOR,%)_emit.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -o $@ $<
+
+# ---- Metal discipline pipeline ----------------------------------------
+# slang -> .metal source -> .air -> .metallib. xcrun-only; skip on non-macOS.
+
+$(EMITTED)/%.metal: emit-shaders
+	@mkdir -p $(EMITTED)
+	$(SLANGC) -target metal -stage compute -entry main \
+	  -o $@ /tmp/godot_speech_emit/$*.slang
+
+$(EMITTED)/%.air: $(EMITTED)/%.metal
+	xcrun -sdk macosx metal -c $< -o $@
+
+$(EMITTED)/%.metallib: $(EMITTED)/%.air
+	xcrun -sdk macosx metallib $< -o $@
+
+clean:
+	rm -rf $(EMITTED)

--- a/tests/slang_validate/frame_energy_test.cpp
+++ b/tests/slang_validate/frame_energy_test.cpp
@@ -1,0 +1,121 @@
+// Real-input validator for Speech.SlangCodegen.FrameEnergy.
+//
+// Reference: lean/Speech/SlangCodegen/FrameEnergy.lean. Per 10 ms frame
+// (480 mono float32 samples at 48 kHz),
+//   energy[f] = Σ_{s=0..479} (samples[f·480 + s])²
+//
+// Strict left-to-right fp32 accumulation via fma — the CPU reference
+// here mirrors the kernel's accumulation order exactly, so the
+// comparison is bit-exact (0 ULP tolerance).
+//
+// Test fixture (3 frames × 480 samples):
+//   frame 0 — pure silence (all zeros), energy = 0
+//   frame 1 — DC at 0.5, energy = 480 · 0.25 = 120
+//   frame 2 — alternating +0.5 / −0.5, energy = 480 · 0.25 = 120
+//
+// One thread group of 64 (matches [numthreads(64,1,1)]) is enough for
+// 3 frames; threads 3..63 hit the early-return via f >= numFrames.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "frame_energy_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N_FRAMES         = 3;
+    constexpr uint32_t SAMPLES_PER_FRAME = 480;
+    constexpr uint32_t GROUP_SIZE       = 64;  // numthreads(64,1,1)
+
+    FrameEnergyParams_0 params{N_FRAMES, SAMPLES_PER_FRAME};
+
+    // ---- Build input PCM.
+    std::vector<float> samples(N_FRAMES * SAMPLES_PER_FRAME, 0.0f);
+    // frame 0: silence (already zero).
+    // frame 1: DC at 0.5.
+    for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
+        samples[1 * SAMPLES_PER_FRAME + s] = 0.5f;
+    }
+    // frame 2: alternating ±0.5.
+    for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
+        samples[2 * SAMPLES_PER_FRAME + s] = (s % 2 == 0) ? 0.5f : -0.5f;
+    }
+
+    std::vector<float> energy(N_FRAMES, 0.0f);
+
+    GlobalParams_0 gp{};
+    gp.params_0      = &params;
+    gp.samples_0.data  = samples.data();   gp.samples_0.count  = samples.size();
+    gp.energy_0.data   = energy.data();    gp.energy_0.count   = energy.size();
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    // ---- Reference: in-order fma over the same samples. Bit-exact target.
+    float ref[N_FRAMES] = {0.0f, 0.0f, 0.0f};
+    for (uint32_t f = 0; f < N_FRAMES; ++f) {
+        float acc = 0.0f;
+        for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
+            const float x = samples[f * SAMPLES_PER_FRAME + s];
+            acc = std::fma(x, x, acc);
+        }
+        ref[f] = acc;
+    }
+
+    int   fails        = 0;
+    float max_abs_diff = 0.0f;
+    for (uint32_t f = 0; f < N_FRAMES; ++f) {
+        const float d = std::fabs(energy[f] - ref[f]);
+        if (d > max_abs_diff) max_abs_diff = d;
+        if (d != 0.0f) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "frame_energy bit-exact mismatch at f=%u: got %g, expected %g (diff %g)\n",
+                    f, energy[f], ref[f], d);
+            }
+            ++fails;
+        }
+    }
+
+    // ---- Sanity: hand-computed analytic values.
+    // frame 0: 0;  frame 1: 480 · 0.25 = 120;  frame 2: 480 · 0.25 = 120.
+    // (Bit-exact only against `ref` above — analytic check is a wider
+    // ULP-tolerant sanity floor so a totally bogus kernel still trips.)
+    const float analytic[N_FRAMES] = {0.0f, 120.0f, 120.0f};
+    for (uint32_t f = 0; f < N_FRAMES; ++f) {
+        if (std::fabs(energy[f] - analytic[f]) > 1e-3f) {
+            std::fprintf(stderr,
+                "frame_energy analytic mismatch at f=%u: got %g, expected ≈%g\n",
+                f, energy[f], analytic[f]);
+            ++fails;
+        }
+    }
+
+    // ---- Pad-thread early-return: threads 3..63 must NOT write past energy[2].
+    // Detected indirectly: if the kernel wrote past the buffer we'd have
+    // ASAN/UBSAN complaints; otherwise the GROUP_SIZE pad is fine.
+    (void)GROUP_SIZE;
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "frame_energy: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("frame_energy: %u/%u frames OK (max_abs_diff=%g, %.1fms)\n",
+                    N_FRAMES, N_FRAMES, max_abs_diff, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "frame_energy: %d FAIL\n", fails);
+    return 1;
+}

--- a/tests/slang_validate/frame_energy_test.cpp
+++ b/tests/slang_validate/frame_energy_test.cpp
@@ -27,95 +27,98 @@
 static constexpr double kBudgetSeconds = 5.0;
 
 int main() {
-    const auto t0 = std::chrono::steady_clock::now();
+	const auto t0 = std::chrono::steady_clock::now();
 
-    constexpr uint32_t N_FRAMES         = 3;
-    constexpr uint32_t SAMPLES_PER_FRAME = 480;
-    constexpr uint32_t GROUP_SIZE       = 64;  // numthreads(64,1,1)
+	constexpr uint32_t N_FRAMES = 3;
+	constexpr uint32_t SAMPLES_PER_FRAME = 480;
+	constexpr uint32_t GROUP_SIZE = 64; // numthreads(64,1,1)
 
-    FrameEnergyParams_0 params{N_FRAMES, SAMPLES_PER_FRAME};
+	FrameEnergyParams_0 params{ N_FRAMES, SAMPLES_PER_FRAME };
 
-    // ---- Build input PCM.
-    std::vector<float> samples(N_FRAMES * SAMPLES_PER_FRAME, 0.0f);
-    // frame 0: silence (already zero).
-    // frame 1: DC at 0.5.
-    for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
-        samples[1 * SAMPLES_PER_FRAME + s] = 0.5f;
-    }
-    // frame 2: alternating ±0.5.
-    for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
-        samples[2 * SAMPLES_PER_FRAME + s] = (s % 2 == 0) ? 0.5f : -0.5f;
-    }
+	// ---- Build input PCM.
+	std::vector<float> samples(N_FRAMES * SAMPLES_PER_FRAME, 0.0f);
+	// frame 0: silence (already zero).
+	// frame 1: DC at 0.5.
+	for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
+		samples[1 * SAMPLES_PER_FRAME + s] = 0.5f;
+	}
+	// frame 2: alternating ±0.5.
+	for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
+		samples[2 * SAMPLES_PER_FRAME + s] = (s % 2 == 0) ? 0.5f : -0.5f;
+	}
 
-    std::vector<float> energy(N_FRAMES, 0.0f);
+	std::vector<float> energy(N_FRAMES, 0.0f);
 
-    GlobalParams_0 gp{};
-    gp.params_0      = &params;
-    gp.samples_0.data  = samples.data();   gp.samples_0.count  = samples.size();
-    gp.energy_0.data   = energy.data();    gp.energy_0.count   = energy.size();
+	GlobalParams_0 gp{};
+	gp.params_0 = &params;
+	gp.samples_0.data = samples.data();
+	gp.samples_0.count = samples.size();
+	gp.energy_0.data = energy.data();
+	gp.energy_0.count = energy.size();
 
-    ComputeVaryingInput vi{};
-    vi.startGroupID = uint3(0, 0, 0);
-    vi.endGroupID   = uint3(1, 1, 1);
-    main_0(&vi, nullptr, &gp);
+	ComputeVaryingInput vi{};
+	vi.startGroupID = uint3(0, 0, 0);
+	vi.endGroupID = uint3(1, 1, 1);
+	main_0(&vi, nullptr, &gp);
 
-    // ---- Reference: in-order fma over the same samples. Bit-exact target.
-    float ref[N_FRAMES] = {0.0f, 0.0f, 0.0f};
-    for (uint32_t f = 0; f < N_FRAMES; ++f) {
-        float acc = 0.0f;
-        for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
-            const float x = samples[f * SAMPLES_PER_FRAME + s];
-            acc = std::fma(x, x, acc);
-        }
-        ref[f] = acc;
-    }
+	// ---- Reference: in-order fma over the same samples. Bit-exact target.
+	float ref[N_FRAMES] = { 0.0f, 0.0f, 0.0f };
+	for (uint32_t f = 0; f < N_FRAMES; ++f) {
+		float acc = 0.0f;
+		for (uint32_t s = 0; s < SAMPLES_PER_FRAME; ++s) {
+			const float x = samples[f * SAMPLES_PER_FRAME + s];
+			acc = std::fma(x, x, acc);
+		}
+		ref[f] = acc;
+	}
 
-    int   fails        = 0;
-    float max_abs_diff = 0.0f;
-    for (uint32_t f = 0; f < N_FRAMES; ++f) {
-        const float d = std::fabs(energy[f] - ref[f]);
-        if (d > max_abs_diff) max_abs_diff = d;
-        if (d != 0.0f) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "frame_energy bit-exact mismatch at f=%u: got %g, expected %g (diff %g)\n",
-                    f, energy[f], ref[f], d);
-            }
-            ++fails;
-        }
-    }
+	int fails = 0;
+	float max_abs_diff = 0.0f;
+	for (uint32_t f = 0; f < N_FRAMES; ++f) {
+		const float d = std::fabs(energy[f] - ref[f]);
+		if (d > max_abs_diff)
+			max_abs_diff = d;
+		if (d != 0.0f) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"frame_energy bit-exact mismatch at f=%u: got %g, expected %g (diff %g)\n",
+						f, energy[f], ref[f], d);
+			}
+			++fails;
+		}
+	}
 
-    // ---- Sanity: hand-computed analytic values.
-    // frame 0: 0;  frame 1: 480 · 0.25 = 120;  frame 2: 480 · 0.25 = 120.
-    // (Bit-exact only against `ref` above — analytic check is a wider
-    // ULP-tolerant sanity floor so a totally bogus kernel still trips.)
-    const float analytic[N_FRAMES] = {0.0f, 120.0f, 120.0f};
-    for (uint32_t f = 0; f < N_FRAMES; ++f) {
-        if (std::fabs(energy[f] - analytic[f]) > 1e-3f) {
-            std::fprintf(stderr,
-                "frame_energy analytic mismatch at f=%u: got %g, expected ≈%g\n",
-                f, energy[f], analytic[f]);
-            ++fails;
-        }
-    }
+	// ---- Sanity: hand-computed analytic values.
+	// frame 0: 0;  frame 1: 480 · 0.25 = 120;  frame 2: 480 · 0.25 = 120.
+	// (Bit-exact only against `ref` above — analytic check is a wider
+	// ULP-tolerant sanity floor so a totally bogus kernel still trips.)
+	const float analytic[N_FRAMES] = { 0.0f, 120.0f, 120.0f };
+	for (uint32_t f = 0; f < N_FRAMES; ++f) {
+		if (std::fabs(energy[f] - analytic[f]) > 1e-3f) {
+			std::fprintf(stderr,
+					"frame_energy analytic mismatch at f=%u: got %g, expected ≈%g\n",
+					f, energy[f], analytic[f]);
+			++fails;
+		}
+	}
 
-    // ---- Pad-thread early-return: threads 3..63 must NOT write past energy[2].
-    // Detected indirectly: if the kernel wrote past the buffer we'd have
-    // ASAN/UBSAN complaints; otherwise the GROUP_SIZE pad is fine.
-    (void)GROUP_SIZE;
+	// ---- Pad-thread early-return: threads 3..63 must NOT write past energy[2].
+	// Detected indirectly: if the kernel wrote past the buffer we'd have
+	// ASAN/UBSAN complaints; otherwise the GROUP_SIZE pad is fine.
+	(void)GROUP_SIZE;
 
-    const auto t1 = std::chrono::steady_clock::now();
-    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
-    if (elapsed > kBudgetSeconds) {
-        std::fprintf(stderr, "frame_energy: TIMEOUT — %.3fs > %.1fs\n",
-                     elapsed, kBudgetSeconds);
-        return 2;
-    }
-    if (fails == 0) {
-        std::printf("frame_energy: %u/%u frames OK (max_abs_diff=%g, %.1fms)\n",
-                    N_FRAMES, N_FRAMES, max_abs_diff, elapsed * 1000.0);
-        return 0;
-    }
-    std::fprintf(stderr, "frame_energy: %d FAIL\n", fails);
-    return 1;
+	const auto t1 = std::chrono::steady_clock::now();
+	const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+	if (elapsed > kBudgetSeconds) {
+		std::fprintf(stderr, "frame_energy: TIMEOUT — %.3fs > %.1fs\n",
+				elapsed, kBudgetSeconds);
+		return 2;
+	}
+	if (fails == 0) {
+		std::printf("frame_energy: %u/%u frames OK (max_abs_diff=%g, %.1fms)\n",
+				N_FRAMES, N_FRAMES, max_abs_diff, elapsed * 1000.0);
+		return 0;
+	}
+	std::fprintf(stderr, "frame_energy: %d FAIL\n", fails);
+	return 1;
 }

--- a/tests/slang_validate/framing_cursor_test.cpp
+++ b/tests/slang_validate/framing_cursor_test.cpp
@@ -33,14 +33,13 @@ static constexpr double kBudgetSeconds = 5.0;
 
 // Lean-spec-faithful reference: integer divmod arithmetic.
 static void reference_policy(
-    const uint32_t* newSamples, uint32_t numTicks, uint32_t frameSize,
-    uint32_t& carry, uint32_t* framesEmitted)
-{
-    for (uint32_t i = 0; i < numTicks; ++i) {
-        const uint32_t total = carry + newSamples[i];
-        framesEmitted[i] = total / frameSize;
-        carry            = total % frameSize;
-    }
+		const uint32_t *newSamples, uint32_t numTicks, uint32_t frameSize,
+		uint32_t &carry, uint32_t *framesEmitted) {
+	for (uint32_t i = 0; i < numTicks; ++i) {
+		const uint32_t total = carry + newSamples[i];
+		framesEmitted[i] = total / frameSize;
+		carry = total % frameSize;
+	}
 }
 
 // Literal translation of the speech_processor.cpp:130 loop, including
@@ -53,209 +52,216 @@ static void reference_policy(
 static constexpr uint32_t kBuggyLoopFuse = 1'000'000u;
 
 struct BuggyResult {
-    uint32_t framesEmitted;
-    bool     hit_fuse;
+	uint32_t framesEmitted;
+	bool hit_fuse;
 };
 
 static BuggyResult buggy_speech_processor_cpp_loop(
-    uint32_t prior_carry, uint32_t newSamples, uint32_t frameSize)
-{
-    // total samples available = prior_carry + newSamples.
-    // speech_processor.cpp sets resampled_frame_count = prior_carry +
-    // (resampler return); then resets offset = 0 and loops:
-    //   while (offset < resampled_frame_count - frameSize) {
-    //     emit; offset += frameSize;
-    //   }
-    uint32_t resampled_frame_count = prior_carry + newSamples;
-    uint32_t offset                = 0u;
-    uint32_t frames                = 0u;
-    uint32_t fuse                  = 0u;
-    while (offset < resampled_frame_count - frameSize) {  // ← unsigned underflow
-        offset += frameSize;
-        ++frames;
-        if (++fuse > kBuggyLoopFuse) {
-            return {frames, true};
-        }
-    }
-    return {frames, false};
+		uint32_t prior_carry, uint32_t newSamples, uint32_t frameSize) {
+	// total samples available = prior_carry + newSamples.
+	// speech_processor.cpp sets resampled_frame_count = prior_carry +
+	// (resampler return); then resets offset = 0 and loops:
+	//   while (offset < resampled_frame_count - frameSize) {
+	//     emit; offset += frameSize;
+	//   }
+	uint32_t resampled_frame_count = prior_carry + newSamples;
+	uint32_t offset = 0u;
+	uint32_t frames = 0u;
+	uint32_t fuse = 0u;
+	while (offset < resampled_frame_count - frameSize) { // ← unsigned underflow
+		offset += frameSize;
+		++frames;
+		if (++fuse > kBuggyLoopFuse) {
+			return { frames, true };
+		}
+	}
+	return { frames, false };
 }
 
 // Run the kernel over `count` ticks starting at `newSamples`, with
 // stateIO carried across dispatches.
 static void dispatch_kernel(
-    const uint32_t* newSamples, uint32_t* framesEmitted,
-    uint32_t count, uint32_t frameSize, uint32_t* stateIO)
-{
-    FramingCursorParams_0 params{count, frameSize};
-    GlobalParams_0 gp{};
-    gp.params_0           = &params;
-    gp.newSamples_0.data    = const_cast<uint32_t*>(newSamples);
-    gp.newSamples_0.count   = count;
-    gp.framesEmitted_0.data  = framesEmitted;
-    gp.framesEmitted_0.count = count;
-    gp.stateIO_0.data       = stateIO;
-    gp.stateIO_0.count      = 1;
+		const uint32_t *newSamples, uint32_t *framesEmitted,
+		uint32_t count, uint32_t frameSize, uint32_t *stateIO) {
+	FramingCursorParams_0 params{ count, frameSize };
+	GlobalParams_0 gp{};
+	gp.params_0 = &params;
+	gp.newSamples_0.data = const_cast<uint32_t *>(newSamples);
+	gp.newSamples_0.count = count;
+	gp.framesEmitted_0.data = framesEmitted;
+	gp.framesEmitted_0.count = count;
+	gp.stateIO_0.data = stateIO;
+	gp.stateIO_0.count = 1;
 
-    ComputeVaryingInput vi{};
-    vi.startGroupID = uint3(0, 0, 0);
-    vi.endGroupID   = uint3(1, 1, 1);
-    main_0(&vi, nullptr, &gp);
+	ComputeVaryingInput vi{};
+	vi.startGroupID = uint3(0, 0, 0);
+	vi.endGroupID = uint3(1, 1, 1);
+	main_0(&vi, nullptr, &gp);
 }
 
 int main() {
-    const auto t0 = std::chrono::steady_clock::now();
+	const auto t0 = std::chrono::steady_clock::now();
 
-    constexpr uint32_t FRAME_SIZE = 480u;
+	constexpr uint32_t FRAME_SIZE = 480u;
 
-    // ---- Job 1: long varied sequence, kernel vs reference.
-    //
-    // Mix of mid-size, large, exact-multiple, and tiny ticks. The tiny
-    // ticks (e.g. 128) test the "below-frameSize" case without
-    // triggering the bug (they accumulate over multiple ticks until a
-    // frame can be emitted).
-    const uint32_t ticks[] = {
-        2048,  2048,  2048,    // happy path: 4-5 frames each tick
-         960,  1920,           // exact multiples of 480
-         128,   128,   128,    // tiny — 3 ticks before first frame emit
-          47,  4801,           // odd, prime-ish
-         512,   479,     1,    // 479+1 = 480 → exactly-one-frame tick
-        4321,
-    };
-    constexpr uint32_t N_TICKS = sizeof(ticks) / sizeof(ticks[0]);
+	// ---- Job 1: long varied sequence, kernel vs reference.
+	//
+	// Mix of mid-size, large, exact-multiple, and tiny ticks. The tiny
+	// ticks (e.g. 128) test the "below-frameSize" case without
+	// triggering the bug (they accumulate over multiple ticks until a
+	// frame can be emitted).
+	const uint32_t ticks[] = {
+		2048,
+		2048,
+		2048, // happy path: 4-5 frames each tick
+		960,
+		1920, // exact multiples of 480
+		128,
+		128,
+		128, // tiny — 3 ticks before first frame emit
+		47,
+		4801, // odd, prime-ish
+		512,
+		479,
+		1, // 479+1 = 480 → exactly-one-frame tick
+		4321,
+	};
+	constexpr uint32_t N_TICKS = sizeof(ticks) / sizeof(ticks[0]);
 
-    uint32_t kernel_frames[N_TICKS] = {};
-    uint32_t kernel_state[1]        = {0u};
-    dispatch_kernel(ticks, kernel_frames, N_TICKS, FRAME_SIZE, kernel_state);
+	uint32_t kernel_frames[N_TICKS] = {};
+	uint32_t kernel_state[1] = { 0u };
+	dispatch_kernel(ticks, kernel_frames, N_TICKS, FRAME_SIZE, kernel_state);
 
-    uint32_t ref_frames[N_TICKS] = {};
-    uint32_t ref_carry           = 0u;
-    reference_policy(ticks, N_TICKS, FRAME_SIZE, ref_carry, ref_frames);
+	uint32_t ref_frames[N_TICKS] = {};
+	uint32_t ref_carry = 0u;
+	reference_policy(ticks, N_TICKS, FRAME_SIZE, ref_carry, ref_frames);
 
-    int fails = 0;
-    for (uint32_t i = 0; i < N_TICKS; ++i) {
-        if (kernel_frames[i] != ref_frames[i]) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "framing_cursor (kernel vs ref) mismatch at i=%u: "
-                    "got %u, expected %u (newSamples=%u)\n",
-                    i, kernel_frames[i], ref_frames[i], ticks[i]);
-            }
-            ++fails;
-        }
-    }
-    if (kernel_state[0] != ref_carry) {
-        std::fprintf(stderr,
-            "framing_cursor end-carry mismatch: kernel %u, ref %u\n",
-            kernel_state[0], ref_carry);
-        ++fails;
-    }
+	int fails = 0;
+	for (uint32_t i = 0; i < N_TICKS; ++i) {
+		if (kernel_frames[i] != ref_frames[i]) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"framing_cursor (kernel vs ref) mismatch at i=%u: "
+						"got %u, expected %u (newSamples=%u)\n",
+						i, kernel_frames[i], ref_frames[i], ticks[i]);
+			}
+			++fails;
+		}
+	}
+	if (kernel_state[0] != ref_carry) {
+		std::fprintf(stderr,
+				"framing_cursor end-carry mismatch: kernel %u, ref %u\n",
+				kernel_state[0], ref_carry);
+		++fails;
+	}
 
-    // ---- Job 2: split dispatch — first 7 ticks, then remainder.
-    constexpr uint32_t SPLIT = 7u;
-    uint32_t split_frames[N_TICKS] = {};
-    uint32_t split_state[1]        = {0u};
-    dispatch_kernel(ticks,           split_frames,           SPLIT, FRAME_SIZE, split_state);
-    dispatch_kernel(ticks + SPLIT,   split_frames + SPLIT,   N_TICKS - SPLIT, FRAME_SIZE, split_state);
+	// ---- Job 2: split dispatch — first 7 ticks, then remainder.
+	constexpr uint32_t SPLIT = 7u;
+	uint32_t split_frames[N_TICKS] = {};
+	uint32_t split_state[1] = { 0u };
+	dispatch_kernel(ticks, split_frames, SPLIT, FRAME_SIZE, split_state);
+	dispatch_kernel(ticks + SPLIT, split_frames + SPLIT, N_TICKS - SPLIT, FRAME_SIZE, split_state);
 
-    for (uint32_t i = 0; i < N_TICKS; ++i) {
-        if (split_frames[i] != kernel_frames[i]) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "framing_cursor (split vs one-shot) mismatch at i=%u: "
-                    "got %u, expected %u\n",
-                    i, split_frames[i], kernel_frames[i]);
-            }
-            ++fails;
-        }
-    }
-    if (split_state[0] != kernel_state[0]) {
-        std::fprintf(stderr,
-            "framing_cursor split-end-carry mismatch: split %u, one-shot %u\n",
-            split_state[0], kernel_state[0]);
-        ++fails;
-    }
+	for (uint32_t i = 0; i < N_TICKS; ++i) {
+		if (split_frames[i] != kernel_frames[i]) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"framing_cursor (split vs one-shot) mismatch at i=%u: "
+						"got %u, expected %u\n",
+						i, split_frames[i], kernel_frames[i]);
+			}
+			++fails;
+		}
+	}
+	if (split_state[0] != kernel_state[0]) {
+		std::fprintf(stderr,
+				"framing_cursor split-end-carry mismatch: split %u, one-shot %u\n",
+				split_state[0], kernel_state[0]);
+		++fails;
+	}
 
-    // ---- Job 3: demonstrate the bug in the speech_processor.cpp:130 loop.
-    //
-    // Two divergence cases:
-    //   (a) Underflow:  resampled_frame_count < frameSize ⇒ buggy loop
-    //                   thinks ~4 G frames are available, runs to fuse.
-    //   (b) Off-by-one: resampled_frame_count == frameSize ⇒ buggy loop
-    //                   emits 0, kernel correctly emits 1.
+	// ---- Job 3: demonstrate the bug in the speech_processor.cpp:130 loop.
+	//
+	// Two divergence cases:
+	//   (a) Underflow:  resampled_frame_count < frameSize ⇒ buggy loop
+	//                   thinks ~4 G frames are available, runs to fuse.
+	//   (b) Off-by-one: resampled_frame_count == frameSize ⇒ buggy loop
+	//                   emits 0, kernel correctly emits 1.
 
-    struct Case {
-        uint32_t prior_carry;
-        uint32_t newSamples;
-        uint32_t expected_kernel_frames;
-        const char* label;
-    };
-    const Case cases[] = {
-        // (a) underflow: prior_carry = 0, newSamples = 100 (< 480)
-        { 0u,   100u,   0u, "underflow: 0+100" },
-        // (a) underflow: prior_carry = 50, newSamples = 0 (resampler returned 0)
-        { 50u,  0u,     0u, "underflow: 50+0" },
-        // (b) off-by-one: total == frameSize exactly
-        { 0u,   FRAME_SIZE,                 1u, "off-by-one: 0+480"  },
-        { 240u, FRAME_SIZE - 240u,          1u, "off-by-one: 240+240"},
-        // happy path (both should agree)
-        { 0u,   2 * FRAME_SIZE,             2u, "happy: 0+960" },
-    };
+	struct Case {
+		uint32_t prior_carry;
+		uint32_t newSamples;
+		uint32_t expected_kernel_frames;
+		const char *label;
+	};
+	const Case cases[] = {
+		// (a) underflow: prior_carry = 0, newSamples = 100 (< 480)
+		{ 0u, 100u, 0u, "underflow: 0+100" },
+		// (a) underflow: prior_carry = 50, newSamples = 0 (resampler returned 0)
+		{ 50u, 0u, 0u, "underflow: 50+0" },
+		// (b) off-by-one: total == frameSize exactly
+		{ 0u, FRAME_SIZE, 1u, "off-by-one: 0+480" },
+		{ 240u, FRAME_SIZE - 240u, 1u, "off-by-one: 240+240" },
+		// happy path (both should agree)
+		{ 0u, 2 * FRAME_SIZE, 2u, "happy: 0+960" },
+	};
 
-    int diff_found = 0;
-    std::printf("framing_cursor diff against speech_processor.cpp:130 loop:\n");
-    for (const auto& c : cases) {
-        // Kernel result
-        uint32_t k_frames[1] = {0u};
-        uint32_t k_state[1]  = {c.prior_carry};
-        dispatch_kernel(&c.newSamples, k_frames, 1, FRAME_SIZE, k_state);
+	int diff_found = 0;
+	std::printf("framing_cursor diff against speech_processor.cpp:130 loop:\n");
+	for (const auto &c : cases) {
+		// Kernel result
+		uint32_t k_frames[1] = { 0u };
+		uint32_t k_state[1] = { c.prior_carry };
+		dispatch_kernel(&c.newSamples, k_frames, 1, FRAME_SIZE, k_state);
 
-        // Buggy C++ result
-        BuggyResult b = buggy_speech_processor_cpp_loop(
-            c.prior_carry, c.newSamples, FRAME_SIZE);
+		// Buggy C++ result
+		BuggyResult b = buggy_speech_processor_cpp_loop(
+				c.prior_carry, c.newSamples, FRAME_SIZE);
 
-        const bool agree = (k_frames[0] == b.framesEmitted) && !b.hit_fuse;
-        std::printf("  %-28s kernel=%u  buggy=%u%s  expected=%u  %s\n",
-                    c.label,
-                    k_frames[0], b.framesEmitted,
-                    b.hit_fuse ? "(FUSE-CAPPED)" : "",
-                    c.expected_kernel_frames,
-                    agree ? "AGREE" : "DIFF");
+		const bool agree = (k_frames[0] == b.framesEmitted) && !b.hit_fuse;
+		std::printf("  %-28s kernel=%u  buggy=%u%s  expected=%u  %s\n",
+				c.label,
+				k_frames[0], b.framesEmitted,
+				b.hit_fuse ? "(FUSE-CAPPED)" : "",
+				c.expected_kernel_frames,
+				agree ? "AGREE" : "DIFF");
 
-        if (k_frames[0] != c.expected_kernel_frames) {
-            std::fprintf(stderr,
-                "framing_cursor kernel disagrees with hand-checked "
-                "oracle on '%s': got %u, expected %u\n",
-                c.label, k_frames[0], c.expected_kernel_frames);
-            ++fails;
-        }
-        if (!agree) ++diff_found;
-    }
+		if (k_frames[0] != c.expected_kernel_frames) {
+			std::fprintf(stderr,
+					"framing_cursor kernel disagrees with hand-checked "
+					"oracle on '%s': got %u, expected %u\n",
+					c.label, k_frames[0], c.expected_kernel_frames);
+			++fails;
+		}
+		if (!agree)
+			++diff_found;
+	}
 
-    // We *require* at least one diff to demonstrate the bug. If both
-    // agree everywhere, either the bug is gone (great — note it!) or
-    // the harness regressed (bad — fix it).
-    if (diff_found == 0) {
-        std::fprintf(stderr,
-            "framing_cursor: expected at least one DIFF case to demonstrate "
-            "the speech_processor.cpp:130 underflow/off-by-one bug — got 0. "
-            "Either the bug was fixed (update this comment + the decision doc) "
-            "or the harness regressed.\n");
-        ++fails;
-    }
+	// We *require* at least one diff to demonstrate the bug. If both
+	// agree everywhere, either the bug is gone (great — note it!) or
+	// the harness regressed (bad — fix it).
+	if (diff_found == 0) {
+		std::fprintf(stderr,
+				"framing_cursor: expected at least one DIFF case to demonstrate "
+				"the speech_processor.cpp:130 underflow/off-by-one bug — got 0. "
+				"Either the bug was fixed (update this comment + the decision doc) "
+				"or the harness regressed.\n");
+		++fails;
+	}
 
-    const auto t1 = std::chrono::steady_clock::now();
-    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
-    if (elapsed > kBudgetSeconds) {
-        std::fprintf(stderr, "framing_cursor: TIMEOUT — %.3fs > %.1fs\n",
-                     elapsed, kBudgetSeconds);
-        return 2;
-    }
-    if (fails == 0) {
-        std::printf("framing_cursor: %u ticks OK + %d bug-demo diffs vs "
-                    "speech_processor.cpp:130 (%.1fms)\n",
-                    N_TICKS, diff_found, elapsed * 1000.0);
-        return 0;
-    }
-    std::fprintf(stderr, "framing_cursor: %d FAIL\n", fails);
-    return 1;
+	const auto t1 = std::chrono::steady_clock::now();
+	const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+	if (elapsed > kBudgetSeconds) {
+		std::fprintf(stderr, "framing_cursor: TIMEOUT — %.3fs > %.1fs\n",
+				elapsed, kBudgetSeconds);
+		return 2;
+	}
+	if (fails == 0) {
+		std::printf("framing_cursor: %u ticks OK + %d bug-demo diffs vs "
+					"speech_processor.cpp:130 (%.1fms)\n",
+				N_TICKS, diff_found, elapsed * 1000.0);
+		return 0;
+	}
+	std::fprintf(stderr, "framing_cursor: %d FAIL\n", fails);
+	return 1;
 }

--- a/tests/slang_validate/framing_cursor_test.cpp
+++ b/tests/slang_validate/framing_cursor_test.cpp
@@ -1,0 +1,261 @@
+// Real-input validator for Speech.SlangCodegen.FramingCursor.
+//
+// Reference: lean/Speech/SlangCodegen/FramingCursor.lean. Encodes the
+// capture-buffer framing-cursor policy. Per audio-thread tick with
+// `newSamples[i]` newly-resampled samples available:
+//
+//   total           = carry + newSamples[i]
+//   framesEmitted[i] = total / frameSize     // integer division
+//   nextCarry       = total mod frameSize
+//
+// This harness has three jobs:
+//   1. Verify the kernel matches the safe-math reference frame-for-frame
+//      across a long, varied tick sequence (bit-exact on uint counts).
+//   2. Verify state carry-over by splitting the sequence across two
+//      dispatches.
+//   3. Demonstrate the divergence between the kernel (safe) and the
+//      buggy loop currently in speech_processor.cpp:130 (unsigned
+//      subtraction with underflow). The bug case fires when
+//      `carry + newSamples < frameSize` on a tick where the original
+//      C++ would compute `resampled_frame_count - frameSize` and
+//      underflow.
+//
+// Job 3 is the entire reason this kernel exists — it pins the first
+// concrete diff between speech_processor.cpp and the Lean spec.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+
+#include "framing_cursor_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+// Lean-spec-faithful reference: integer divmod arithmetic.
+static void reference_policy(
+    const uint32_t* newSamples, uint32_t numTicks, uint32_t frameSize,
+    uint32_t& carry, uint32_t* framesEmitted)
+{
+    for (uint32_t i = 0; i < numTicks; ++i) {
+        const uint32_t total = carry + newSamples[i];
+        framesEmitted[i] = total / frameSize;
+        carry            = total % frameSize;
+    }
+}
+
+// Literal translation of the speech_processor.cpp:130 loop, including
+// the unsigned-subtraction bug. Used in Job 3 to demonstrate the diff.
+//
+// CAVEAT: in the underflow case this loop would run effectively
+// forever in the real engine. We cap iteration here at a generous
+// fuse so the test terminates and we can report the divergence
+// without hanging CI.
+static constexpr uint32_t kBuggyLoopFuse = 1'000'000u;
+
+struct BuggyResult {
+    uint32_t framesEmitted;
+    bool     hit_fuse;
+};
+
+static BuggyResult buggy_speech_processor_cpp_loop(
+    uint32_t prior_carry, uint32_t newSamples, uint32_t frameSize)
+{
+    // total samples available = prior_carry + newSamples.
+    // speech_processor.cpp sets resampled_frame_count = prior_carry +
+    // (resampler return); then resets offset = 0 and loops:
+    //   while (offset < resampled_frame_count - frameSize) {
+    //     emit; offset += frameSize;
+    //   }
+    uint32_t resampled_frame_count = prior_carry + newSamples;
+    uint32_t offset                = 0u;
+    uint32_t frames                = 0u;
+    uint32_t fuse                  = 0u;
+    while (offset < resampled_frame_count - frameSize) {  // ← unsigned underflow
+        offset += frameSize;
+        ++frames;
+        if (++fuse > kBuggyLoopFuse) {
+            return {frames, true};
+        }
+    }
+    return {frames, false};
+}
+
+// Run the kernel over `count` ticks starting at `newSamples`, with
+// stateIO carried across dispatches.
+static void dispatch_kernel(
+    const uint32_t* newSamples, uint32_t* framesEmitted,
+    uint32_t count, uint32_t frameSize, uint32_t* stateIO)
+{
+    FramingCursorParams_0 params{count, frameSize};
+    GlobalParams_0 gp{};
+    gp.params_0           = &params;
+    gp.newSamples_0.data    = const_cast<uint32_t*>(newSamples);
+    gp.newSamples_0.count   = count;
+    gp.framesEmitted_0.data  = framesEmitted;
+    gp.framesEmitted_0.count = count;
+    gp.stateIO_0.data       = stateIO;
+    gp.stateIO_0.count      = 1;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+}
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t FRAME_SIZE = 480u;
+
+    // ---- Job 1: long varied sequence, kernel vs reference.
+    //
+    // Mix of mid-size, large, exact-multiple, and tiny ticks. The tiny
+    // ticks (e.g. 128) test the "below-frameSize" case without
+    // triggering the bug (they accumulate over multiple ticks until a
+    // frame can be emitted).
+    const uint32_t ticks[] = {
+        2048,  2048,  2048,    // happy path: 4-5 frames each tick
+         960,  1920,           // exact multiples of 480
+         128,   128,   128,    // tiny — 3 ticks before first frame emit
+          47,  4801,           // odd, prime-ish
+         512,   479,     1,    // 479+1 = 480 → exactly-one-frame tick
+        4321,
+    };
+    constexpr uint32_t N_TICKS = sizeof(ticks) / sizeof(ticks[0]);
+
+    uint32_t kernel_frames[N_TICKS] = {};
+    uint32_t kernel_state[1]        = {0u};
+    dispatch_kernel(ticks, kernel_frames, N_TICKS, FRAME_SIZE, kernel_state);
+
+    uint32_t ref_frames[N_TICKS] = {};
+    uint32_t ref_carry           = 0u;
+    reference_policy(ticks, N_TICKS, FRAME_SIZE, ref_carry, ref_frames);
+
+    int fails = 0;
+    for (uint32_t i = 0; i < N_TICKS; ++i) {
+        if (kernel_frames[i] != ref_frames[i]) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "framing_cursor (kernel vs ref) mismatch at i=%u: "
+                    "got %u, expected %u (newSamples=%u)\n",
+                    i, kernel_frames[i], ref_frames[i], ticks[i]);
+            }
+            ++fails;
+        }
+    }
+    if (kernel_state[0] != ref_carry) {
+        std::fprintf(stderr,
+            "framing_cursor end-carry mismatch: kernel %u, ref %u\n",
+            kernel_state[0], ref_carry);
+        ++fails;
+    }
+
+    // ---- Job 2: split dispatch — first 7 ticks, then remainder.
+    constexpr uint32_t SPLIT = 7u;
+    uint32_t split_frames[N_TICKS] = {};
+    uint32_t split_state[1]        = {0u};
+    dispatch_kernel(ticks,           split_frames,           SPLIT, FRAME_SIZE, split_state);
+    dispatch_kernel(ticks + SPLIT,   split_frames + SPLIT,   N_TICKS - SPLIT, FRAME_SIZE, split_state);
+
+    for (uint32_t i = 0; i < N_TICKS; ++i) {
+        if (split_frames[i] != kernel_frames[i]) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "framing_cursor (split vs one-shot) mismatch at i=%u: "
+                    "got %u, expected %u\n",
+                    i, split_frames[i], kernel_frames[i]);
+            }
+            ++fails;
+        }
+    }
+    if (split_state[0] != kernel_state[0]) {
+        std::fprintf(stderr,
+            "framing_cursor split-end-carry mismatch: split %u, one-shot %u\n",
+            split_state[0], kernel_state[0]);
+        ++fails;
+    }
+
+    // ---- Job 3: demonstrate the bug in the speech_processor.cpp:130 loop.
+    //
+    // Two divergence cases:
+    //   (a) Underflow:  resampled_frame_count < frameSize ⇒ buggy loop
+    //                   thinks ~4 G frames are available, runs to fuse.
+    //   (b) Off-by-one: resampled_frame_count == frameSize ⇒ buggy loop
+    //                   emits 0, kernel correctly emits 1.
+
+    struct Case {
+        uint32_t prior_carry;
+        uint32_t newSamples;
+        uint32_t expected_kernel_frames;
+        const char* label;
+    };
+    const Case cases[] = {
+        // (a) underflow: prior_carry = 0, newSamples = 100 (< 480)
+        { 0u,   100u,   0u, "underflow: 0+100" },
+        // (a) underflow: prior_carry = 50, newSamples = 0 (resampler returned 0)
+        { 50u,  0u,     0u, "underflow: 50+0" },
+        // (b) off-by-one: total == frameSize exactly
+        { 0u,   FRAME_SIZE,                 1u, "off-by-one: 0+480"  },
+        { 240u, FRAME_SIZE - 240u,          1u, "off-by-one: 240+240"},
+        // happy path (both should agree)
+        { 0u,   2 * FRAME_SIZE,             2u, "happy: 0+960" },
+    };
+
+    int diff_found = 0;
+    std::printf("framing_cursor diff against speech_processor.cpp:130 loop:\n");
+    for (const auto& c : cases) {
+        // Kernel result
+        uint32_t k_frames[1] = {0u};
+        uint32_t k_state[1]  = {c.prior_carry};
+        dispatch_kernel(&c.newSamples, k_frames, 1, FRAME_SIZE, k_state);
+
+        // Buggy C++ result
+        BuggyResult b = buggy_speech_processor_cpp_loop(
+            c.prior_carry, c.newSamples, FRAME_SIZE);
+
+        const bool agree = (k_frames[0] == b.framesEmitted) && !b.hit_fuse;
+        std::printf("  %-28s kernel=%u  buggy=%u%s  expected=%u  %s\n",
+                    c.label,
+                    k_frames[0], b.framesEmitted,
+                    b.hit_fuse ? "(FUSE-CAPPED)" : "",
+                    c.expected_kernel_frames,
+                    agree ? "AGREE" : "DIFF");
+
+        if (k_frames[0] != c.expected_kernel_frames) {
+            std::fprintf(stderr,
+                "framing_cursor kernel disagrees with hand-checked "
+                "oracle on '%s': got %u, expected %u\n",
+                c.label, k_frames[0], c.expected_kernel_frames);
+            ++fails;
+        }
+        if (!agree) ++diff_found;
+    }
+
+    // We *require* at least one diff to demonstrate the bug. If both
+    // agree everywhere, either the bug is gone (great — note it!) or
+    // the harness regressed (bad — fix it).
+    if (diff_found == 0) {
+        std::fprintf(stderr,
+            "framing_cursor: expected at least one DIFF case to demonstrate "
+            "the speech_processor.cpp:130 underflow/off-by-one bug — got 0. "
+            "Either the bug was fixed (update this comment + the decision doc) "
+            "or the harness regressed.\n");
+        ++fails;
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "framing_cursor: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("framing_cursor: %u ticks OK + %d bug-demo diffs vs "
+                    "speech_processor.cpp:130 (%.1fms)\n",
+                    N_TICKS, diff_found, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "framing_cursor: %d FAIL\n", fails);
+    return 1;
+}

--- a/tests/slang_validate/jitter_append_test.cpp
+++ b/tests/slang_validate/jitter_append_test.cpp
@@ -27,253 +27,262 @@
 static constexpr double kBudgetSeconds = 5.0;
 
 struct State {
-    uint32_t currentSeq;
-    uint32_t currentSeqValid;
-    uint32_t currentSize;
+	uint32_t currentSeq;
+	uint32_t currentSeqValid;
+	uint32_t currentSize;
 };
 
 struct EventOut {
-    uint32_t fillerCount;
-    uint32_t appendNew;
-    uint32_t slotIsValid;
-    uint32_t slotIdx;
-    uint32_t dropFromFront;
+	uint32_t fillerCount;
+	uint32_t appendNew;
+	uint32_t slotIsValid;
+	uint32_t slotIdx;
+	uint32_t dropFromFront;
 };
 
 // CPU reference, kept literally identical to the Lean spec.
 static void reference_policy(
-    const uint32_t* incomingSeq, uint32_t numEvents, uint32_t maxSize,
-    State& st, EventOut* out)
-{
-    for (uint32_t i = 0; i < numEvents; ++i) {
-        const uint32_t seq = incomingSeq[i];
-        if (st.currentSeqValid == 0u) {
-            out[i].fillerCount = 0u;
-            out[i].appendNew   = 1u;
-            out[i].slotIsValid = 0u;
-            out[i].slotIdx     = 0u;
-            const uint32_t sizeAfter = st.currentSize + 1u;
-            const uint32_t drop = (sizeAfter > maxSize) ? (sizeAfter - maxSize) : 0u;
-            out[i].dropFromFront = drop;
-            st.currentSize       = sizeAfter - drop;
-            st.currentSeq        = seq;
-            st.currentSeqValid   = 1u;
-        } else if (seq > st.currentSeq) {
-            const uint32_t offset = seq - st.currentSeq;
-            const uint32_t filler = offset - 1u;
-            out[i].fillerCount = filler;
-            out[i].appendNew   = 1u;
-            out[i].slotIsValid = 0u;
-            out[i].slotIdx     = 0u;
-            const uint32_t sizeAfter = st.currentSize + filler + 1u;
-            const uint32_t drop = (sizeAfter > maxSize) ? (sizeAfter - maxSize) : 0u;
-            out[i].dropFromFront = drop;
-            st.currentSize       = sizeAfter - drop;
-            st.currentSeq        = seq;
-        } else {
-            const uint32_t diff = st.currentSeq - seq;
-            out[i].fillerCount   = 0u;
-            out[i].appendNew     = 0u;
-            out[i].dropFromFront = 0u;
-            if (st.currentSize >= 1u + diff) {
-                out[i].slotIsValid = 1u;
-                out[i].slotIdx     = st.currentSize - 1u - diff;
-            } else {
-                out[i].slotIsValid = 0u;
-                out[i].slotIdx     = 0u;
-            }
-            // currentSeq / currentSize unchanged
-        }
-    }
+		const uint32_t *incomingSeq, uint32_t numEvents, uint32_t maxSize,
+		State &st, EventOut *out) {
+	for (uint32_t i = 0; i < numEvents; ++i) {
+		const uint32_t seq = incomingSeq[i];
+		if (st.currentSeqValid == 0u) {
+			out[i].fillerCount = 0u;
+			out[i].appendNew = 1u;
+			out[i].slotIsValid = 0u;
+			out[i].slotIdx = 0u;
+			const uint32_t sizeAfter = st.currentSize + 1u;
+			const uint32_t drop = (sizeAfter > maxSize) ? (sizeAfter - maxSize) : 0u;
+			out[i].dropFromFront = drop;
+			st.currentSize = sizeAfter - drop;
+			st.currentSeq = seq;
+			st.currentSeqValid = 1u;
+		} else if (seq > st.currentSeq) {
+			const uint32_t offset = seq - st.currentSeq;
+			const uint32_t filler = offset - 1u;
+			out[i].fillerCount = filler;
+			out[i].appendNew = 1u;
+			out[i].slotIsValid = 0u;
+			out[i].slotIdx = 0u;
+			const uint32_t sizeAfter = st.currentSize + filler + 1u;
+			const uint32_t drop = (sizeAfter > maxSize) ? (sizeAfter - maxSize) : 0u;
+			out[i].dropFromFront = drop;
+			st.currentSize = sizeAfter - drop;
+			st.currentSeq = seq;
+		} else {
+			const uint32_t diff = st.currentSeq - seq;
+			out[i].fillerCount = 0u;
+			out[i].appendNew = 0u;
+			out[i].dropFromFront = 0u;
+			if (st.currentSize >= 1u + diff) {
+				out[i].slotIsValid = 1u;
+				out[i].slotIdx = st.currentSize - 1u - diff;
+			} else {
+				out[i].slotIsValid = 0u;
+				out[i].slotIdx = 0u;
+			}
+			// currentSeq / currentSize unchanged
+		}
+	}
 }
 
 static void dispatch_kernel(
-    const uint32_t* incomingSeq, uint32_t numEvents, uint32_t maxSize,
-    State& st, EventOut* out)
-{
-    JitterAppendParams_0 params{numEvents, maxSize};
+		const uint32_t *incomingSeq, uint32_t numEvents, uint32_t maxSize,
+		State &st, EventOut *out) {
+	JitterAppendParams_0 params{ numEvents, maxSize };
 
-    uint32_t fillerCount[64]   = {};
-    uint32_t appendNew[64]     = {};
-    uint32_t slotIsValid[64]   = {};
-    uint32_t slotIdx[64]       = {};
-    uint32_t dropFromFront[64] = {};
-    uint32_t stateIO[3]        = {st.currentSeq, st.currentSeqValid, st.currentSize};
+	uint32_t fillerCount[64] = {};
+	uint32_t appendNew[64] = {};
+	uint32_t slotIsValid[64] = {};
+	uint32_t slotIdx[64] = {};
+	uint32_t dropFromFront[64] = {};
+	uint32_t stateIO[3] = { st.currentSeq, st.currentSeqValid, st.currentSize };
 
-    if (numEvents > 64) {
-        std::fprintf(stderr, "fixture too large for static buffer\n");
-        std::abort();
-    }
+	if (numEvents > 64) {
+		std::fprintf(stderr, "fixture too large for static buffer\n");
+		std::abort();
+	}
 
-    GlobalParams_0 gp{};
-    gp.params_0                = &params;
-    gp.incomingSeq_0.data      = const_cast<uint32_t*>(incomingSeq);
-    gp.incomingSeq_0.count     = numEvents;
-    gp.fillerCount_0.data      = fillerCount;       gp.fillerCount_0.count   = numEvents;
-    gp.appendNew_0.data        = appendNew;         gp.appendNew_0.count     = numEvents;
-    gp.slotIsValid_0.data      = slotIsValid;       gp.slotIsValid_0.count   = numEvents;
-    gp.slotIdx_0.data          = slotIdx;           gp.slotIdx_0.count       = numEvents;
-    gp.dropFromFront_0.data    = dropFromFront;     gp.dropFromFront_0.count = numEvents;
-    gp.stateIO_0.data          = stateIO;           gp.stateIO_0.count       = 3;
+	GlobalParams_0 gp{};
+	gp.params_0 = &params;
+	gp.incomingSeq_0.data = const_cast<uint32_t *>(incomingSeq);
+	gp.incomingSeq_0.count = numEvents;
+	gp.fillerCount_0.data = fillerCount;
+	gp.fillerCount_0.count = numEvents;
+	gp.appendNew_0.data = appendNew;
+	gp.appendNew_0.count = numEvents;
+	gp.slotIsValid_0.data = slotIsValid;
+	gp.slotIsValid_0.count = numEvents;
+	gp.slotIdx_0.data = slotIdx;
+	gp.slotIdx_0.count = numEvents;
+	gp.dropFromFront_0.data = dropFromFront;
+	gp.dropFromFront_0.count = numEvents;
+	gp.stateIO_0.data = stateIO;
+	gp.stateIO_0.count = 3;
 
-    ComputeVaryingInput vi{};
-    vi.startGroupID = uint3(0, 0, 0);
-    vi.endGroupID   = uint3(1, 1, 1);
-    main_0(&vi, nullptr, &gp);
+	ComputeVaryingInput vi{};
+	vi.startGroupID = uint3(0, 0, 0);
+	vi.endGroupID = uint3(1, 1, 1);
+	main_0(&vi, nullptr, &gp);
 
-    for (uint32_t i = 0; i < numEvents; ++i) {
-        out[i].fillerCount   = fillerCount[i];
-        out[i].appendNew     = appendNew[i];
-        out[i].slotIsValid   = slotIsValid[i];
-        out[i].slotIdx       = slotIdx[i];
-        out[i].dropFromFront = dropFromFront[i];
-    }
-    st.currentSeq      = stateIO[0];
-    st.currentSeqValid = stateIO[1];
-    st.currentSize     = stateIO[2];
+	for (uint32_t i = 0; i < numEvents; ++i) {
+		out[i].fillerCount = fillerCount[i];
+		out[i].appendNew = appendNew[i];
+		out[i].slotIsValid = slotIsValid[i];
+		out[i].slotIdx = slotIdx[i];
+		out[i].dropFromFront = dropFromFront[i];
+	}
+	st.currentSeq = stateIO[0];
+	st.currentSeqValid = stateIO[1];
+	st.currentSize = stateIO[2];
 }
 
-static bool event_equal(const EventOut& a, const EventOut& b) {
-    if (a.fillerCount   != b.fillerCount)   return false;
-    if (a.appendNew     != b.appendNew)     return false;
-    if (a.slotIsValid   != b.slotIsValid)   return false;
-    if (a.dropFromFront != b.dropFromFront) return false;
-    // slotIdx only meaningful when slotIsValid == 1
-    if (a.slotIsValid == 1u && a.slotIdx != b.slotIdx) return false;
-    return true;
+static bool event_equal(const EventOut &a, const EventOut &b) {
+	if (a.fillerCount != b.fillerCount)
+		return false;
+	if (a.appendNew != b.appendNew)
+		return false;
+	if (a.slotIsValid != b.slotIsValid)
+		return false;
+	if (a.dropFromFront != b.dropFromFront)
+		return false;
+	// slotIdx only meaningful when slotIsValid == 1
+	if (a.slotIsValid == 1u && a.slotIdx != b.slotIdx)
+		return false;
+	return true;
 }
 
 int main() {
-    const auto t0 = std::chrono::steady_clock::now();
+	const auto t0 = std::chrono::steady_clock::now();
 
-    constexpr uint32_t MAX_SIZE = 16u;
+	constexpr uint32_t MAX_SIZE = 16u;
 
-    // Fixture sequence designed to walk every branch.
-    //
-    //  i  seq  expected behavior
-    //  0   42  first-packet → fillerCount=0, appendNew=1, size: 0→1
-    //  1   43  in-order → filler=0, append=1, size: 1→2
-    //  2   45  gap of 2 → filler=1, append=1, size: 2→4
-    //  3  100  large gap (offset=55) → filler=54, append=1, size: 4+54+1=59, drop=43, newSize=16
-    //  4  100  duplicate → filler=0, append=0, slotIsValid=1 (size>=1), slotIdx=size-1=15
-    //  5   95  out-of-order (offset=-5, diff=5) → slotIsValid=1 (size=16 >= 1+5), slotIdx=15-5=10
-    //  6    1  out-of-order, too old (diff=99) → slotIsValid=0
-    //  7  101  forward by 1 → filler=0, append=1, sizeAfter=17, drop=1, newSize=16
+	// Fixture sequence designed to walk every branch.
+	//
+	//  i  seq  expected behavior
+	//  0   42  first-packet → fillerCount=0, appendNew=1, size: 0→1
+	//  1   43  in-order → filler=0, append=1, size: 1→2
+	//  2   45  gap of 2 → filler=1, append=1, size: 2→4
+	//  3  100  large gap (offset=55) → filler=54, append=1, size: 4+54+1=59, drop=43, newSize=16
+	//  4  100  duplicate → filler=0, append=0, slotIsValid=1 (size>=1), slotIdx=size-1=15
+	//  5   95  out-of-order (offset=-5, diff=5) → slotIsValid=1 (size=16 >= 1+5), slotIdx=15-5=10
+	//  6    1  out-of-order, too old (diff=99) → slotIsValid=0
+	//  7  101  forward by 1 → filler=0, append=1, sizeAfter=17, drop=1, newSize=16
 
-    const uint32_t seqs[] = {42u, 43u, 45u, 100u, 100u, 95u, 1u, 101u};
-    constexpr uint32_t N  = sizeof(seqs) / sizeof(seqs[0]);
+	const uint32_t seqs[] = { 42u, 43u, 45u, 100u, 100u, 95u, 1u, 101u };
+	constexpr uint32_t N = sizeof(seqs) / sizeof(seqs[0]);
 
-    // Hand-checked oracle (slotIdx only checked when slotIsValid==1).
-    const EventOut oracle[N] = {
-        // fillerCount, appendNew, slotIsValid, slotIdx, dropFromFront
-        {  0u, 1u, 0u,  0u,  0u },   // i=0
-        {  0u, 1u, 0u,  0u,  0u },   // i=1
-        {  1u, 1u, 0u,  0u,  0u },   // i=2
-        { 54u, 1u, 0u,  0u, 43u },   // i=3
-        {  0u, 0u, 1u, 15u,  0u },   // i=4
-        {  0u, 0u, 1u, 10u,  0u },   // i=5
-        {  0u, 0u, 0u,  0u,  0u },   // i=6
-        {  0u, 1u, 0u,  0u,  1u },   // i=7
-    };
+	// Hand-checked oracle (slotIdx only checked when slotIsValid==1).
+	const EventOut oracle[N] = {
+		// fillerCount, appendNew, slotIsValid, slotIdx, dropFromFront
+		{ 0u, 1u, 0u, 0u, 0u }, // i=0
+		{ 0u, 1u, 0u, 0u, 0u }, // i=1
+		{ 1u, 1u, 0u, 0u, 0u }, // i=2
+		{ 54u, 1u, 0u, 0u, 43u }, // i=3
+		{ 0u, 0u, 1u, 15u, 0u }, // i=4
+		{ 0u, 0u, 1u, 10u, 0u }, // i=5
+		{ 0u, 0u, 0u, 0u, 0u }, // i=6
+		{ 0u, 1u, 0u, 0u, 1u }, // i=7
+	};
 
-    // Expected final state after all 8 events.
-    const State oracle_end = {/*currentSeq*/ 101u, /*valid*/ 1u, /*currentSize*/ 16u};
+	// Expected final state after all 8 events.
+	const State oracle_end = { /*currentSeq*/ 101u, /*valid*/ 1u, /*currentSize*/ 16u };
 
-    int fails = 0;
+	int fails = 0;
 
-    // ---- Pass 1: kernel one-shot.
-    State k_st = {0u, 0u, 0u};
-    EventOut k_out[N];
-    dispatch_kernel(seqs, N, MAX_SIZE, k_st, k_out);
+	// ---- Pass 1: kernel one-shot.
+	State k_st = { 0u, 0u, 0u };
+	EventOut k_out[N];
+	dispatch_kernel(seqs, N, MAX_SIZE, k_st, k_out);
 
-    // ---- Pass 2: CPU reference.
-    State r_st = {0u, 0u, 0u};
-    EventOut r_out[N];
-    reference_policy(seqs, N, MAX_SIZE, r_st, r_out);
+	// ---- Pass 2: CPU reference.
+	State r_st = { 0u, 0u, 0u };
+	EventOut r_out[N];
+	reference_policy(seqs, N, MAX_SIZE, r_st, r_out);
 
-    // Kernel vs reference (bit-exact).
-    for (uint32_t i = 0; i < N; ++i) {
-        if (!event_equal(k_out[i], r_out[i])) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "jitter_append (kernel vs ref) mismatch at i=%u seq=%u: "
-                    "kernel {fc=%u,a=%u,sv=%u,si=%u,df=%u} "
-                    "ref {fc=%u,a=%u,sv=%u,si=%u,df=%u}\n",
-                    i, seqs[i],
-                    k_out[i].fillerCount, k_out[i].appendNew, k_out[i].slotIsValid,
-                    k_out[i].slotIdx, k_out[i].dropFromFront,
-                    r_out[i].fillerCount, r_out[i].appendNew, r_out[i].slotIsValid,
-                    r_out[i].slotIdx, r_out[i].dropFromFront);
-            }
-            ++fails;
-        }
-    }
+	// Kernel vs reference (bit-exact).
+	for (uint32_t i = 0; i < N; ++i) {
+		if (!event_equal(k_out[i], r_out[i])) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"jitter_append (kernel vs ref) mismatch at i=%u seq=%u: "
+						"kernel {fc=%u,a=%u,sv=%u,si=%u,df=%u} "
+						"ref {fc=%u,a=%u,sv=%u,si=%u,df=%u}\n",
+						i, seqs[i],
+						k_out[i].fillerCount, k_out[i].appendNew, k_out[i].slotIsValid,
+						k_out[i].slotIdx, k_out[i].dropFromFront,
+						r_out[i].fillerCount, r_out[i].appendNew, r_out[i].slotIsValid,
+						r_out[i].slotIdx, r_out[i].dropFromFront);
+			}
+			++fails;
+		}
+	}
 
-    // Kernel vs oracle.
-    for (uint32_t i = 0; i < N; ++i) {
-        if (!event_equal(k_out[i], oracle[i])) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "jitter_append (kernel vs oracle) mismatch at i=%u seq=%u: "
-                    "kernel {fc=%u,a=%u,sv=%u,si=%u,df=%u} "
-                    "oracle {fc=%u,a=%u,sv=%u,si=%u,df=%u}\n",
-                    i, seqs[i],
-                    k_out[i].fillerCount, k_out[i].appendNew, k_out[i].slotIsValid,
-                    k_out[i].slotIdx, k_out[i].dropFromFront,
-                    oracle[i].fillerCount, oracle[i].appendNew, oracle[i].slotIsValid,
-                    oracle[i].slotIdx, oracle[i].dropFromFront);
-            }
-            ++fails;
-        }
-    }
+	// Kernel vs oracle.
+	for (uint32_t i = 0; i < N; ++i) {
+		if (!event_equal(k_out[i], oracle[i])) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"jitter_append (kernel vs oracle) mismatch at i=%u seq=%u: "
+						"kernel {fc=%u,a=%u,sv=%u,si=%u,df=%u} "
+						"oracle {fc=%u,a=%u,sv=%u,si=%u,df=%u}\n",
+						i, seqs[i],
+						k_out[i].fillerCount, k_out[i].appendNew, k_out[i].slotIsValid,
+						k_out[i].slotIdx, k_out[i].dropFromFront,
+						oracle[i].fillerCount, oracle[i].appendNew, oracle[i].slotIsValid,
+						oracle[i].slotIdx, oracle[i].dropFromFront);
+			}
+			++fails;
+		}
+	}
 
-    // Final state check.
-    if (k_st.currentSeq != oracle_end.currentSeq ||
-        k_st.currentSeqValid != oracle_end.currentSeqValid ||
-        k_st.currentSize != oracle_end.currentSize) {
-        std::fprintf(stderr,
-            "jitter_append final state mismatch: kernel {seq=%u,valid=%u,size=%u} "
-            "oracle {seq=%u,valid=%u,size=%u}\n",
-            k_st.currentSeq, k_st.currentSeqValid, k_st.currentSize,
-            oracle_end.currentSeq, oracle_end.currentSeqValid, oracle_end.currentSize);
-        ++fails;
-    }
+	// Final state check.
+	if (k_st.currentSeq != oracle_end.currentSeq ||
+			k_st.currentSeqValid != oracle_end.currentSeqValid ||
+			k_st.currentSize != oracle_end.currentSize) {
+		std::fprintf(stderr,
+				"jitter_append final state mismatch: kernel {seq=%u,valid=%u,size=%u} "
+				"oracle {seq=%u,valid=%u,size=%u}\n",
+				k_st.currentSeq, k_st.currentSeqValid, k_st.currentSize,
+				oracle_end.currentSeq, oracle_end.currentSeqValid, oracle_end.currentSize);
+		++fails;
+	}
 
-    // ---- Pass 3: split dispatch — first 4 events, then remainder.
-    State sp_st = {0u, 0u, 0u};
-    EventOut sp_out[N];
-    constexpr uint32_t SPLIT = 4u;
-    dispatch_kernel(seqs,         SPLIT,     MAX_SIZE, sp_st, sp_out);
-    dispatch_kernel(seqs + SPLIT, N - SPLIT, MAX_SIZE, sp_st, sp_out + SPLIT);
+	// ---- Pass 3: split dispatch — first 4 events, then remainder.
+	State sp_st = { 0u, 0u, 0u };
+	EventOut sp_out[N];
+	constexpr uint32_t SPLIT = 4u;
+	dispatch_kernel(seqs, SPLIT, MAX_SIZE, sp_st, sp_out);
+	dispatch_kernel(seqs + SPLIT, N - SPLIT, MAX_SIZE, sp_st, sp_out + SPLIT);
 
-    for (uint32_t i = 0; i < N; ++i) {
-        if (!event_equal(sp_out[i], k_out[i])) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "jitter_append (split vs one-shot) mismatch at i=%u\n", i);
-            }
-            ++fails;
-        }
-    }
-    if (sp_st.currentSeq != k_st.currentSeq ||
-        sp_st.currentSeqValid != k_st.currentSeqValid ||
-        sp_st.currentSize != k_st.currentSize) {
-        std::fprintf(stderr, "jitter_append split-end-state mismatch\n");
-        ++fails;
-    }
+	for (uint32_t i = 0; i < N; ++i) {
+		if (!event_equal(sp_out[i], k_out[i])) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"jitter_append (split vs one-shot) mismatch at i=%u\n", i);
+			}
+			++fails;
+		}
+	}
+	if (sp_st.currentSeq != k_st.currentSeq ||
+			sp_st.currentSeqValid != k_st.currentSeqValid ||
+			sp_st.currentSize != k_st.currentSize) {
+		std::fprintf(stderr, "jitter_append split-end-state mismatch\n");
+		++fails;
+	}
 
-    const auto t1 = std::chrono::steady_clock::now();
-    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
-    if (elapsed > kBudgetSeconds) {
-        std::fprintf(stderr, "jitter_append: TIMEOUT — %.3fs > %.1fs\n",
-                     elapsed, kBudgetSeconds);
-        return 2;
-    }
-    if (fails == 0) {
-        std::printf("jitter_append: %u/%u events OK (kernel vs ref/oracle/split + final state; %.1fms)\n",
-                    N, N, elapsed * 1000.0);
-        return 0;
-    }
-    std::fprintf(stderr, "jitter_append: %d FAIL\n", fails);
-    return 1;
+	const auto t1 = std::chrono::steady_clock::now();
+	const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+	if (elapsed > kBudgetSeconds) {
+		std::fprintf(stderr, "jitter_append: TIMEOUT — %.3fs > %.1fs\n",
+				elapsed, kBudgetSeconds);
+		return 2;
+	}
+	if (fails == 0) {
+		std::printf("jitter_append: %u/%u events OK (kernel vs ref/oracle/split + final state; %.1fms)\n",
+				N, N, elapsed * 1000.0);
+		return 0;
+	}
+	std::fprintf(stderr, "jitter_append: %d FAIL\n", fails);
+	return 1;
 }

--- a/tests/slang_validate/jitter_append_test.cpp
+++ b/tests/slang_validate/jitter_append_test.cpp
@@ -1,0 +1,279 @@
+// Real-input validator for Speech.SlangCodegen.JitterAppend.
+//
+// Reference: lean/Speech/SlangCodegen/JitterAppend.lean. Encodes the
+// per-packet jitter-buffer evolution policy that runs inside
+// Speech::on_received_audio_packet (speech.cpp:570+).
+//
+// Cases covered by the fixture:
+//   0: first packet (currentSeqValid = 0 → forward-by-1 path)
+//   1: in-order next packet
+//   2: gap of 2 (skipped one sequence ID)
+//   3: large gap that overflows maxSize → dropFromFront triggers
+//   4: duplicate (offset == 0)
+//   5: out-of-order, in-range (slot exists)
+//   6: out-of-order, too old (slot < 0)
+//
+// Each case is checked against (a) an independent CPU reference
+// implementation that mirrors the Lean spec, and (b) a hand-checked
+// oracle of the expected output tuple.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include "jitter_append_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+struct State {
+    uint32_t currentSeq;
+    uint32_t currentSeqValid;
+    uint32_t currentSize;
+};
+
+struct EventOut {
+    uint32_t fillerCount;
+    uint32_t appendNew;
+    uint32_t slotIsValid;
+    uint32_t slotIdx;
+    uint32_t dropFromFront;
+};
+
+// CPU reference, kept literally identical to the Lean spec.
+static void reference_policy(
+    const uint32_t* incomingSeq, uint32_t numEvents, uint32_t maxSize,
+    State& st, EventOut* out)
+{
+    for (uint32_t i = 0; i < numEvents; ++i) {
+        const uint32_t seq = incomingSeq[i];
+        if (st.currentSeqValid == 0u) {
+            out[i].fillerCount = 0u;
+            out[i].appendNew   = 1u;
+            out[i].slotIsValid = 0u;
+            out[i].slotIdx     = 0u;
+            const uint32_t sizeAfter = st.currentSize + 1u;
+            const uint32_t drop = (sizeAfter > maxSize) ? (sizeAfter - maxSize) : 0u;
+            out[i].dropFromFront = drop;
+            st.currentSize       = sizeAfter - drop;
+            st.currentSeq        = seq;
+            st.currentSeqValid   = 1u;
+        } else if (seq > st.currentSeq) {
+            const uint32_t offset = seq - st.currentSeq;
+            const uint32_t filler = offset - 1u;
+            out[i].fillerCount = filler;
+            out[i].appendNew   = 1u;
+            out[i].slotIsValid = 0u;
+            out[i].slotIdx     = 0u;
+            const uint32_t sizeAfter = st.currentSize + filler + 1u;
+            const uint32_t drop = (sizeAfter > maxSize) ? (sizeAfter - maxSize) : 0u;
+            out[i].dropFromFront = drop;
+            st.currentSize       = sizeAfter - drop;
+            st.currentSeq        = seq;
+        } else {
+            const uint32_t diff = st.currentSeq - seq;
+            out[i].fillerCount   = 0u;
+            out[i].appendNew     = 0u;
+            out[i].dropFromFront = 0u;
+            if (st.currentSize >= 1u + diff) {
+                out[i].slotIsValid = 1u;
+                out[i].slotIdx     = st.currentSize - 1u - diff;
+            } else {
+                out[i].slotIsValid = 0u;
+                out[i].slotIdx     = 0u;
+            }
+            // currentSeq / currentSize unchanged
+        }
+    }
+}
+
+static void dispatch_kernel(
+    const uint32_t* incomingSeq, uint32_t numEvents, uint32_t maxSize,
+    State& st, EventOut* out)
+{
+    JitterAppendParams_0 params{numEvents, maxSize};
+
+    uint32_t fillerCount[64]   = {};
+    uint32_t appendNew[64]     = {};
+    uint32_t slotIsValid[64]   = {};
+    uint32_t slotIdx[64]       = {};
+    uint32_t dropFromFront[64] = {};
+    uint32_t stateIO[3]        = {st.currentSeq, st.currentSeqValid, st.currentSize};
+
+    if (numEvents > 64) {
+        std::fprintf(stderr, "fixture too large for static buffer\n");
+        std::abort();
+    }
+
+    GlobalParams_0 gp{};
+    gp.params_0                = &params;
+    gp.incomingSeq_0.data      = const_cast<uint32_t*>(incomingSeq);
+    gp.incomingSeq_0.count     = numEvents;
+    gp.fillerCount_0.data      = fillerCount;       gp.fillerCount_0.count   = numEvents;
+    gp.appendNew_0.data        = appendNew;         gp.appendNew_0.count     = numEvents;
+    gp.slotIsValid_0.data      = slotIsValid;       gp.slotIsValid_0.count   = numEvents;
+    gp.slotIdx_0.data          = slotIdx;           gp.slotIdx_0.count       = numEvents;
+    gp.dropFromFront_0.data    = dropFromFront;     gp.dropFromFront_0.count = numEvents;
+    gp.stateIO_0.data          = stateIO;           gp.stateIO_0.count       = 3;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+
+    for (uint32_t i = 0; i < numEvents; ++i) {
+        out[i].fillerCount   = fillerCount[i];
+        out[i].appendNew     = appendNew[i];
+        out[i].slotIsValid   = slotIsValid[i];
+        out[i].slotIdx       = slotIdx[i];
+        out[i].dropFromFront = dropFromFront[i];
+    }
+    st.currentSeq      = stateIO[0];
+    st.currentSeqValid = stateIO[1];
+    st.currentSize     = stateIO[2];
+}
+
+static bool event_equal(const EventOut& a, const EventOut& b) {
+    if (a.fillerCount   != b.fillerCount)   return false;
+    if (a.appendNew     != b.appendNew)     return false;
+    if (a.slotIsValid   != b.slotIsValid)   return false;
+    if (a.dropFromFront != b.dropFromFront) return false;
+    // slotIdx only meaningful when slotIsValid == 1
+    if (a.slotIsValid == 1u && a.slotIdx != b.slotIdx) return false;
+    return true;
+}
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t MAX_SIZE = 16u;
+
+    // Fixture sequence designed to walk every branch.
+    //
+    //  i  seq  expected behavior
+    //  0   42  first-packet → fillerCount=0, appendNew=1, size: 0→1
+    //  1   43  in-order → filler=0, append=1, size: 1→2
+    //  2   45  gap of 2 → filler=1, append=1, size: 2→4
+    //  3  100  large gap (offset=55) → filler=54, append=1, size: 4+54+1=59, drop=43, newSize=16
+    //  4  100  duplicate → filler=0, append=0, slotIsValid=1 (size>=1), slotIdx=size-1=15
+    //  5   95  out-of-order (offset=-5, diff=5) → slotIsValid=1 (size=16 >= 1+5), slotIdx=15-5=10
+    //  6    1  out-of-order, too old (diff=99) → slotIsValid=0
+    //  7  101  forward by 1 → filler=0, append=1, sizeAfter=17, drop=1, newSize=16
+
+    const uint32_t seqs[] = {42u, 43u, 45u, 100u, 100u, 95u, 1u, 101u};
+    constexpr uint32_t N  = sizeof(seqs) / sizeof(seqs[0]);
+
+    // Hand-checked oracle (slotIdx only checked when slotIsValid==1).
+    const EventOut oracle[N] = {
+        // fillerCount, appendNew, slotIsValid, slotIdx, dropFromFront
+        {  0u, 1u, 0u,  0u,  0u },   // i=0
+        {  0u, 1u, 0u,  0u,  0u },   // i=1
+        {  1u, 1u, 0u,  0u,  0u },   // i=2
+        { 54u, 1u, 0u,  0u, 43u },   // i=3
+        {  0u, 0u, 1u, 15u,  0u },   // i=4
+        {  0u, 0u, 1u, 10u,  0u },   // i=5
+        {  0u, 0u, 0u,  0u,  0u },   // i=6
+        {  0u, 1u, 0u,  0u,  1u },   // i=7
+    };
+
+    // Expected final state after all 8 events.
+    const State oracle_end = {/*currentSeq*/ 101u, /*valid*/ 1u, /*currentSize*/ 16u};
+
+    int fails = 0;
+
+    // ---- Pass 1: kernel one-shot.
+    State k_st = {0u, 0u, 0u};
+    EventOut k_out[N];
+    dispatch_kernel(seqs, N, MAX_SIZE, k_st, k_out);
+
+    // ---- Pass 2: CPU reference.
+    State r_st = {0u, 0u, 0u};
+    EventOut r_out[N];
+    reference_policy(seqs, N, MAX_SIZE, r_st, r_out);
+
+    // Kernel vs reference (bit-exact).
+    for (uint32_t i = 0; i < N; ++i) {
+        if (!event_equal(k_out[i], r_out[i])) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "jitter_append (kernel vs ref) mismatch at i=%u seq=%u: "
+                    "kernel {fc=%u,a=%u,sv=%u,si=%u,df=%u} "
+                    "ref {fc=%u,a=%u,sv=%u,si=%u,df=%u}\n",
+                    i, seqs[i],
+                    k_out[i].fillerCount, k_out[i].appendNew, k_out[i].slotIsValid,
+                    k_out[i].slotIdx, k_out[i].dropFromFront,
+                    r_out[i].fillerCount, r_out[i].appendNew, r_out[i].slotIsValid,
+                    r_out[i].slotIdx, r_out[i].dropFromFront);
+            }
+            ++fails;
+        }
+    }
+
+    // Kernel vs oracle.
+    for (uint32_t i = 0; i < N; ++i) {
+        if (!event_equal(k_out[i], oracle[i])) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "jitter_append (kernel vs oracle) mismatch at i=%u seq=%u: "
+                    "kernel {fc=%u,a=%u,sv=%u,si=%u,df=%u} "
+                    "oracle {fc=%u,a=%u,sv=%u,si=%u,df=%u}\n",
+                    i, seqs[i],
+                    k_out[i].fillerCount, k_out[i].appendNew, k_out[i].slotIsValid,
+                    k_out[i].slotIdx, k_out[i].dropFromFront,
+                    oracle[i].fillerCount, oracle[i].appendNew, oracle[i].slotIsValid,
+                    oracle[i].slotIdx, oracle[i].dropFromFront);
+            }
+            ++fails;
+        }
+    }
+
+    // Final state check.
+    if (k_st.currentSeq != oracle_end.currentSeq ||
+        k_st.currentSeqValid != oracle_end.currentSeqValid ||
+        k_st.currentSize != oracle_end.currentSize) {
+        std::fprintf(stderr,
+            "jitter_append final state mismatch: kernel {seq=%u,valid=%u,size=%u} "
+            "oracle {seq=%u,valid=%u,size=%u}\n",
+            k_st.currentSeq, k_st.currentSeqValid, k_st.currentSize,
+            oracle_end.currentSeq, oracle_end.currentSeqValid, oracle_end.currentSize);
+        ++fails;
+    }
+
+    // ---- Pass 3: split dispatch — first 4 events, then remainder.
+    State sp_st = {0u, 0u, 0u};
+    EventOut sp_out[N];
+    constexpr uint32_t SPLIT = 4u;
+    dispatch_kernel(seqs,         SPLIT,     MAX_SIZE, sp_st, sp_out);
+    dispatch_kernel(seqs + SPLIT, N - SPLIT, MAX_SIZE, sp_st, sp_out + SPLIT);
+
+    for (uint32_t i = 0; i < N; ++i) {
+        if (!event_equal(sp_out[i], k_out[i])) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "jitter_append (split vs one-shot) mismatch at i=%u\n", i);
+            }
+            ++fails;
+        }
+    }
+    if (sp_st.currentSeq != k_st.currentSeq ||
+        sp_st.currentSeqValid != k_st.currentSeqValid ||
+        sp_st.currentSize != k_st.currentSize) {
+        std::fprintf(stderr, "jitter_append split-end-state mismatch\n");
+        ++fails;
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "jitter_append: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("jitter_append: %u/%u events OK (kernel vs ref/oracle/split + final state; %.1fms)\n",
+                    N, N, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "jitter_append: %d FAIL\n", fails);
+    return 1;
+}

--- a/tests/slang_validate/vad_gate_test.cpp
+++ b/tests/slang_validate/vad_gate_test.cpp
@@ -1,0 +1,200 @@
+// Real-input validator for Speech.SlangCodegen.VadGate.
+//
+// Reference: lean/Speech/SlangCodegen/VadGate.lean. Per-frame
+// hysteresis state machine that turns a classifier score stream into
+// a gated boolean. Inherently sequential — kernel dispatch is a
+// single thread group with [numthreads(1,1,1)].
+//
+// This harness:
+//   1. Runs a synthetic 20-frame score sequence through the kernel
+//      in one shot, and through an independent CPU re-implementation
+//      of the same policy. Bit-exact comparison (boolean).
+//   2. Splits the same sequence across two dispatches (frames [0..9]
+//      then [10..19]) and verifies the stateIO carry-over produces
+//      the SAME 20-element gated output. Catches state-init or
+//      carry-over bugs.
+//
+// Parameters: enter=0.6, exit=0.4, hangover=3. Chosen so the test
+// sequence exercises every transition: enter, refresh, hangover
+// countdown to zero, re-enter, exit.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+
+#include "vad_gate_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+// CPU reference implementation of the policy, kept literally identical
+// to the Lean spec in VadGate.lean — including the if/else nesting,
+// because subtle reorderings would diverge in tie-breaks.
+static void reference_policy(
+    const float* score, uint32_t numFrames,
+    float enterThreshold, float exitThreshold, uint32_t hangoverFrames,
+    uint32_t& active, uint32_t& hangover,
+    uint32_t* gated)
+{
+    for (uint32_t i = 0; i < numFrames; ++i) {
+        const float s = score[i];
+        if (active == 0u) {
+            if (s > enterThreshold) {
+                active   = 1u;
+                hangover = hangoverFrames;
+            }
+        } else {
+            if (s > exitThreshold) {
+                hangover = hangoverFrames;
+            } else if (hangover > 0u) {
+                hangover = hangover - 1u;
+            } else {
+                active = 0u;
+            }
+        }
+        gated[i] = active;
+    }
+}
+
+// Run the kernel over [first, first+count) frames, carrying state via stateIO.
+static void dispatch_kernel(
+    const float* score, uint32_t* gated,
+    uint32_t count,
+    const VadGateParams_0& params,
+    uint32_t* stateIO)
+{
+    GlobalParams_0 gp{};
+    gp.params_0       = const_cast<VadGateParams_0*>(&params);
+    gp.score_0.data   = const_cast<float*>(score);  gp.score_0.count   = count;
+    gp.gated_0.data   = gated;                      gp.gated_0.count   = count;
+    gp.stateIO_0.data = stateIO;                    gp.stateIO_0.count = 2;
+
+    ComputeVaryingInput vi{};
+    vi.startGroupID = uint3(0, 0, 0);
+    vi.endGroupID   = uint3(1, 1, 1);
+    main_0(&vi, nullptr, &gp);
+}
+
+int main() {
+    const auto t0 = std::chrono::steady_clock::now();
+
+    constexpr uint32_t N = 20;
+    constexpr float    ENTER     = 0.6f;
+    constexpr float    EXIT      = 0.4f;
+    constexpr uint32_t HANGOVER  = 3u;
+
+    // Synthetic score sequence, hand-designed to exercise every transition:
+    //   i  : score   : phase
+    //   0  : 0.10    : silence
+    //   1  : 0.20    : silence
+    //   2  : 0.70    : enter   (>enter ⇒ active=1, hangover=3)
+    //   3  : 0.80    : sustain (>exit ⇒ refresh hangover=3)
+    //   4  : 0.30    : dip     (≤exit, hangover 3→2, still active)
+    //   5  : 0.30    : dip     (hangover 2→1, still active)
+    //   6  : 0.30    : dip     (hangover 1→0, still active)
+    //   7  : 0.30    : dip     (hangover=0 ⇒ active=0)
+    //   8  : 0.30    : silence (no enter trigger)
+    //   9  : 0.50    : nudge   (not > enter=0.6 ⇒ still silent)
+    //  10  : 0.90    : enter   (>enter ⇒ active=1, hangover=3)
+    //  11  : 0.20    : dip     (hangover 3→2)
+    //  12  : 0.70    : refresh (>exit ⇒ hangover=3 again)
+    //  13  : 0.70    : sustain
+    //  14  : 0.10    : dip     (hangover 3→2)
+    //  15  : 0.10    : dip     (hangover 2→1)
+    //  16  : 0.10    : dip     (hangover 1→0)
+    //  17  : 0.10    : dip     (hangover=0 ⇒ active=0)
+    //  18  : 0.10    : silence
+    //  19  : 0.10    : silence
+    float score[N] = {
+        0.10f, 0.20f, 0.70f, 0.80f, 0.30f, 0.30f, 0.30f, 0.30f, 0.30f, 0.50f,
+        0.90f, 0.20f, 0.70f, 0.70f, 0.10f, 0.10f, 0.10f, 0.10f, 0.10f, 0.10f,
+    };
+
+    // Hand-checked oracle. If the kernel and the CPU reference both
+    // disagree with this, the test design itself is wrong — orthogonal
+    // check against the bit-exact equality below.
+    const uint32_t oracle[N] = {
+        0, 0, 1, 1, 1, 1, 1, 0, 0, 0,
+        1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
+    };
+
+    VadGateParams_0 params{N, ENTER, EXIT, HANGOVER};
+
+    // ---- Pass 1: one-shot dispatch over [0..N).
+    uint32_t gated_one[N]   = {};
+    uint32_t stateIO_one[2] = {0u, 0u};
+    dispatch_kernel(score, gated_one, N, params, stateIO_one);
+
+    // ---- Pass 2: CPU reference.
+    uint32_t gated_ref[N];
+    uint32_t ref_active = 0u, ref_hangover = 0u;
+    reference_policy(score, N, ENTER, EXIT, HANGOVER,
+                     ref_active, ref_hangover, gated_ref);
+
+    int fails = 0;
+
+    // Bit-exact: kernel vs reference.
+    for (uint32_t i = 0; i < N; ++i) {
+        if (gated_one[i] != gated_ref[i]) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vad_gate (one-shot vs ref) mismatch at i=%u: got %u, expected %u (score=%g)\n",
+                    i, gated_one[i], gated_ref[i], score[i]);
+            }
+            ++fails;
+        }
+    }
+
+    // Oracle: catches case where both kernel & ref share the same bug.
+    for (uint32_t i = 0; i < N; ++i) {
+        if (gated_one[i] != oracle[i]) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vad_gate (one-shot vs oracle) mismatch at i=%u: got %u, expected %u (score=%g)\n",
+                    i, gated_one[i], oracle[i], score[i]);
+            }
+            ++fails;
+        }
+    }
+
+    // Kernel must leave stateIO consistent — at i=19 the gate has been
+    // off for 3 frames (17,18,19), so final state should be {active=0, hangover=0}.
+    if (stateIO_one[0] != ref_active || stateIO_one[1] != ref_hangover) {
+        std::fprintf(stderr,
+            "vad_gate stateIO end-state mismatch: kernel {%u, %u}, ref {%u, %u}\n",
+            stateIO_one[0], stateIO_one[1], ref_active, ref_hangover);
+        ++fails;
+    }
+
+    // ---- Pass 3: split dispatch [0..10) + [10..20) with state carry-over.
+    uint32_t gated_split[N]   = {};
+    uint32_t stateIO_split[2] = {0u, 0u};
+    VadGateParams_0 params10{10u, ENTER, EXIT, HANGOVER};
+    dispatch_kernel(score,        gated_split,       10, params10, stateIO_split);
+    dispatch_kernel(score + 10,   gated_split + 10,  10, params10, stateIO_split);
+
+    for (uint32_t i = 0; i < N; ++i) {
+        if (gated_split[i] != gated_one[i]) {
+            if (fails < 5) {
+                std::fprintf(stderr,
+                    "vad_gate (split vs one-shot) mismatch at i=%u: got %u, expected %u (score=%g)\n",
+                    i, gated_split[i], gated_one[i], score[i]);
+            }
+            ++fails;
+        }
+    }
+
+    const auto t1 = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    if (elapsed > kBudgetSeconds) {
+        std::fprintf(stderr, "vad_gate: TIMEOUT — %.3fs > %.1fs\n",
+                     elapsed, kBudgetSeconds);
+        return 2;
+    }
+    if (fails == 0) {
+        std::printf("vad_gate: %u/%u frames OK (one-shot, ref, oracle, split, all match; %.1fms)\n",
+                    N, N, elapsed * 1000.0);
+        return 0;
+    }
+    std::fprintf(stderr, "vad_gate: %d FAIL\n", fails);
+    return 1;
+}

--- a/tests/slang_validate/vad_gate_test.cpp
+++ b/tests/slang_validate/vad_gate_test.cpp
@@ -30,171 +30,208 @@ static constexpr double kBudgetSeconds = 5.0;
 // to the Lean spec in VadGate.lean — including the if/else nesting,
 // because subtle reorderings would diverge in tie-breaks.
 static void reference_policy(
-    const float* score, uint32_t numFrames,
-    float enterThreshold, float exitThreshold, uint32_t hangoverFrames,
-    uint32_t& active, uint32_t& hangover,
-    uint32_t* gated)
-{
-    for (uint32_t i = 0; i < numFrames; ++i) {
-        const float s = score[i];
-        if (active == 0u) {
-            if (s > enterThreshold) {
-                active   = 1u;
-                hangover = hangoverFrames;
-            }
-        } else {
-            if (s > exitThreshold) {
-                hangover = hangoverFrames;
-            } else if (hangover > 0u) {
-                hangover = hangover - 1u;
-            } else {
-                active = 0u;
-            }
-        }
-        gated[i] = active;
-    }
+		const float *score, uint32_t numFrames,
+		float enterThreshold, float exitThreshold, uint32_t hangoverFrames,
+		uint32_t &active, uint32_t &hangover,
+		uint32_t *gated) {
+	for (uint32_t i = 0; i < numFrames; ++i) {
+		const float s = score[i];
+		if (active == 0u) {
+			if (s > enterThreshold) {
+				active = 1u;
+				hangover = hangoverFrames;
+			}
+		} else {
+			if (s > exitThreshold) {
+				hangover = hangoverFrames;
+			} else if (hangover > 0u) {
+				hangover = hangover - 1u;
+			} else {
+				active = 0u;
+			}
+		}
+		gated[i] = active;
+	}
 }
 
 // Run the kernel over [first, first+count) frames, carrying state via stateIO.
 static void dispatch_kernel(
-    const float* score, uint32_t* gated,
-    uint32_t count,
-    const VadGateParams_0& params,
-    uint32_t* stateIO)
-{
-    GlobalParams_0 gp{};
-    gp.params_0       = const_cast<VadGateParams_0*>(&params);
-    gp.score_0.data   = const_cast<float*>(score);  gp.score_0.count   = count;
-    gp.gated_0.data   = gated;                      gp.gated_0.count   = count;
-    gp.stateIO_0.data = stateIO;                    gp.stateIO_0.count = 2;
+		const float *score, uint32_t *gated,
+		uint32_t count,
+		const VadGateParams_0 &params,
+		uint32_t *stateIO) {
+	GlobalParams_0 gp{};
+	gp.params_0 = const_cast<VadGateParams_0 *>(&params);
+	gp.score_0.data = const_cast<float *>(score);
+	gp.score_0.count = count;
+	gp.gated_0.data = gated;
+	gp.gated_0.count = count;
+	gp.stateIO_0.data = stateIO;
+	gp.stateIO_0.count = 2;
 
-    ComputeVaryingInput vi{};
-    vi.startGroupID = uint3(0, 0, 0);
-    vi.endGroupID   = uint3(1, 1, 1);
-    main_0(&vi, nullptr, &gp);
+	ComputeVaryingInput vi{};
+	vi.startGroupID = uint3(0, 0, 0);
+	vi.endGroupID = uint3(1, 1, 1);
+	main_0(&vi, nullptr, &gp);
 }
 
 int main() {
-    const auto t0 = std::chrono::steady_clock::now();
+	const auto t0 = std::chrono::steady_clock::now();
 
-    constexpr uint32_t N = 20;
-    constexpr float    ENTER     = 0.6f;
-    constexpr float    EXIT      = 0.4f;
-    constexpr uint32_t HANGOVER  = 3u;
+	constexpr uint32_t N = 20;
+	constexpr float ENTER = 0.6f;
+	constexpr float EXIT = 0.4f;
+	constexpr uint32_t HANGOVER = 3u;
 
-    // Synthetic score sequence, hand-designed to exercise every transition:
-    //   i  : score   : phase
-    //   0  : 0.10    : silence
-    //   1  : 0.20    : silence
-    //   2  : 0.70    : enter   (>enter ⇒ active=1, hangover=3)
-    //   3  : 0.80    : sustain (>exit ⇒ refresh hangover=3)
-    //   4  : 0.30    : dip     (≤exit, hangover 3→2, still active)
-    //   5  : 0.30    : dip     (hangover 2→1, still active)
-    //   6  : 0.30    : dip     (hangover 1→0, still active)
-    //   7  : 0.30    : dip     (hangover=0 ⇒ active=0)
-    //   8  : 0.30    : silence (no enter trigger)
-    //   9  : 0.50    : nudge   (not > enter=0.6 ⇒ still silent)
-    //  10  : 0.90    : enter   (>enter ⇒ active=1, hangover=3)
-    //  11  : 0.20    : dip     (hangover 3→2)
-    //  12  : 0.70    : refresh (>exit ⇒ hangover=3 again)
-    //  13  : 0.70    : sustain
-    //  14  : 0.10    : dip     (hangover 3→2)
-    //  15  : 0.10    : dip     (hangover 2→1)
-    //  16  : 0.10    : dip     (hangover 1→0)
-    //  17  : 0.10    : dip     (hangover=0 ⇒ active=0)
-    //  18  : 0.10    : silence
-    //  19  : 0.10    : silence
-    float score[N] = {
-        0.10f, 0.20f, 0.70f, 0.80f, 0.30f, 0.30f, 0.30f, 0.30f, 0.30f, 0.50f,
-        0.90f, 0.20f, 0.70f, 0.70f, 0.10f, 0.10f, 0.10f, 0.10f, 0.10f, 0.10f,
-    };
+	// Synthetic score sequence, hand-designed to exercise every transition:
+	//   i  : score   : phase
+	//   0  : 0.10    : silence
+	//   1  : 0.20    : silence
+	//   2  : 0.70    : enter   (>enter ⇒ active=1, hangover=3)
+	//   3  : 0.80    : sustain (>exit ⇒ refresh hangover=3)
+	//   4  : 0.30    : dip     (≤exit, hangover 3→2, still active)
+	//   5  : 0.30    : dip     (hangover 2→1, still active)
+	//   6  : 0.30    : dip     (hangover 1→0, still active)
+	//   7  : 0.30    : dip     (hangover=0 ⇒ active=0)
+	//   8  : 0.30    : silence (no enter trigger)
+	//   9  : 0.50    : nudge   (not > enter=0.6 ⇒ still silent)
+	//  10  : 0.90    : enter   (>enter ⇒ active=1, hangover=3)
+	//  11  : 0.20    : dip     (hangover 3→2)
+	//  12  : 0.70    : refresh (>exit ⇒ hangover=3 again)
+	//  13  : 0.70    : sustain
+	//  14  : 0.10    : dip     (hangover 3→2)
+	//  15  : 0.10    : dip     (hangover 2→1)
+	//  16  : 0.10    : dip     (hangover 1→0)
+	//  17  : 0.10    : dip     (hangover=0 ⇒ active=0)
+	//  18  : 0.10    : silence
+	//  19  : 0.10    : silence
+	float score[N] = {
+		0.10f,
+		0.20f,
+		0.70f,
+		0.80f,
+		0.30f,
+		0.30f,
+		0.30f,
+		0.30f,
+		0.30f,
+		0.50f,
+		0.90f,
+		0.20f,
+		0.70f,
+		0.70f,
+		0.10f,
+		0.10f,
+		0.10f,
+		0.10f,
+		0.10f,
+		0.10f,
+	};
 
-    // Hand-checked oracle. If the kernel and the CPU reference both
-    // disagree with this, the test design itself is wrong — orthogonal
-    // check against the bit-exact equality below.
-    const uint32_t oracle[N] = {
-        0, 0, 1, 1, 1, 1, 1, 0, 0, 0,
-        1, 1, 1, 1, 1, 1, 1, 0, 0, 0,
-    };
+	// Hand-checked oracle. If the kernel and the CPU reference both
+	// disagree with this, the test design itself is wrong — orthogonal
+	// check against the bit-exact equality below.
+	const uint32_t oracle[N] = {
+		0,
+		0,
+		1,
+		1,
+		1,
+		1,
+		1,
+		0,
+		0,
+		0,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		0,
+		0,
+		0,
+	};
 
-    VadGateParams_0 params{N, ENTER, EXIT, HANGOVER};
+	VadGateParams_0 params{ N, ENTER, EXIT, HANGOVER };
 
-    // ---- Pass 1: one-shot dispatch over [0..N).
-    uint32_t gated_one[N]   = {};
-    uint32_t stateIO_one[2] = {0u, 0u};
-    dispatch_kernel(score, gated_one, N, params, stateIO_one);
+	// ---- Pass 1: one-shot dispatch over [0..N).
+	uint32_t gated_one[N] = {};
+	uint32_t stateIO_one[2] = { 0u, 0u };
+	dispatch_kernel(score, gated_one, N, params, stateIO_one);
 
-    // ---- Pass 2: CPU reference.
-    uint32_t gated_ref[N];
-    uint32_t ref_active = 0u, ref_hangover = 0u;
-    reference_policy(score, N, ENTER, EXIT, HANGOVER,
-                     ref_active, ref_hangover, gated_ref);
+	// ---- Pass 2: CPU reference.
+	uint32_t gated_ref[N];
+	uint32_t ref_active = 0u, ref_hangover = 0u;
+	reference_policy(score, N, ENTER, EXIT, HANGOVER,
+			ref_active, ref_hangover, gated_ref);
 
-    int fails = 0;
+	int fails = 0;
 
-    // Bit-exact: kernel vs reference.
-    for (uint32_t i = 0; i < N; ++i) {
-        if (gated_one[i] != gated_ref[i]) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "vad_gate (one-shot vs ref) mismatch at i=%u: got %u, expected %u (score=%g)\n",
-                    i, gated_one[i], gated_ref[i], score[i]);
-            }
-            ++fails;
-        }
-    }
+	// Bit-exact: kernel vs reference.
+	for (uint32_t i = 0; i < N; ++i) {
+		if (gated_one[i] != gated_ref[i]) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"vad_gate (one-shot vs ref) mismatch at i=%u: got %u, expected %u (score=%g)\n",
+						i, gated_one[i], gated_ref[i], score[i]);
+			}
+			++fails;
+		}
+	}
 
-    // Oracle: catches case where both kernel & ref share the same bug.
-    for (uint32_t i = 0; i < N; ++i) {
-        if (gated_one[i] != oracle[i]) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "vad_gate (one-shot vs oracle) mismatch at i=%u: got %u, expected %u (score=%g)\n",
-                    i, gated_one[i], oracle[i], score[i]);
-            }
-            ++fails;
-        }
-    }
+	// Oracle: catches case where both kernel & ref share the same bug.
+	for (uint32_t i = 0; i < N; ++i) {
+		if (gated_one[i] != oracle[i]) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"vad_gate (one-shot vs oracle) mismatch at i=%u: got %u, expected %u (score=%g)\n",
+						i, gated_one[i], oracle[i], score[i]);
+			}
+			++fails;
+		}
+	}
 
-    // Kernel must leave stateIO consistent — at i=19 the gate has been
-    // off for 3 frames (17,18,19), so final state should be {active=0, hangover=0}.
-    if (stateIO_one[0] != ref_active || stateIO_one[1] != ref_hangover) {
-        std::fprintf(stderr,
-            "vad_gate stateIO end-state mismatch: kernel {%u, %u}, ref {%u, %u}\n",
-            stateIO_one[0], stateIO_one[1], ref_active, ref_hangover);
-        ++fails;
-    }
+	// Kernel must leave stateIO consistent — at i=19 the gate has been
+	// off for 3 frames (17,18,19), so final state should be {active=0, hangover=0}.
+	if (stateIO_one[0] != ref_active || stateIO_one[1] != ref_hangover) {
+		std::fprintf(stderr,
+				"vad_gate stateIO end-state mismatch: kernel {%u, %u}, ref {%u, %u}\n",
+				stateIO_one[0], stateIO_one[1], ref_active, ref_hangover);
+		++fails;
+	}
 
-    // ---- Pass 3: split dispatch [0..10) + [10..20) with state carry-over.
-    uint32_t gated_split[N]   = {};
-    uint32_t stateIO_split[2] = {0u, 0u};
-    VadGateParams_0 params10{10u, ENTER, EXIT, HANGOVER};
-    dispatch_kernel(score,        gated_split,       10, params10, stateIO_split);
-    dispatch_kernel(score + 10,   gated_split + 10,  10, params10, stateIO_split);
+	// ---- Pass 3: split dispatch [0..10) + [10..20) with state carry-over.
+	uint32_t gated_split[N] = {};
+	uint32_t stateIO_split[2] = { 0u, 0u };
+	VadGateParams_0 params10{ 10u, ENTER, EXIT, HANGOVER };
+	dispatch_kernel(score, gated_split, 10, params10, stateIO_split);
+	dispatch_kernel(score + 10, gated_split + 10, 10, params10, stateIO_split);
 
-    for (uint32_t i = 0; i < N; ++i) {
-        if (gated_split[i] != gated_one[i]) {
-            if (fails < 5) {
-                std::fprintf(stderr,
-                    "vad_gate (split vs one-shot) mismatch at i=%u: got %u, expected %u (score=%g)\n",
-                    i, gated_split[i], gated_one[i], score[i]);
-            }
-            ++fails;
-        }
-    }
+	for (uint32_t i = 0; i < N; ++i) {
+		if (gated_split[i] != gated_one[i]) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"vad_gate (split vs one-shot) mismatch at i=%u: got %u, expected %u (score=%g)\n",
+						i, gated_split[i], gated_one[i], score[i]);
+			}
+			++fails;
+		}
+	}
 
-    const auto t1 = std::chrono::steady_clock::now();
-    const double elapsed = std::chrono::duration<double>(t1 - t0).count();
-    if (elapsed > kBudgetSeconds) {
-        std::fprintf(stderr, "vad_gate: TIMEOUT — %.3fs > %.1fs\n",
-                     elapsed, kBudgetSeconds);
-        return 2;
-    }
-    if (fails == 0) {
-        std::printf("vad_gate: %u/%u frames OK (one-shot, ref, oracle, split, all match; %.1fms)\n",
-                    N, N, elapsed * 1000.0);
-        return 0;
-    }
-    std::fprintf(stderr, "vad_gate: %d FAIL\n", fails);
-    return 1;
+	const auto t1 = std::chrono::steady_clock::now();
+	const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+	if (elapsed > kBudgetSeconds) {
+		std::fprintf(stderr, "vad_gate: TIMEOUT — %.3fs > %.1fs\n",
+				elapsed, kBudgetSeconds);
+		return 2;
+	}
+	if (fails == 0) {
+		std::printf("vad_gate: %u/%u frames OK (one-shot, ref, oracle, split, all match; %.1fms)\n",
+				N, N, elapsed * 1000.0);
+		return 0;
+	}
+	std::fprintf(stderr, "vad_gate: %d FAIL\n", fails);
+	return 1;
 }

--- a/tests/test_playback_stats.h
+++ b/tests/test_playback_stats.h
@@ -38,7 +38,6 @@
 #include "tests/test_macros.h"
 
 namespace TestPlaybackStats {
-
 TEST_CASE("[SceneTree][PlaybackStats] Initialization and Getters") {
 	SceneTree *tree = SceneTree::get_singleton();
 	Window *original_root_window = tree->get_root();
@@ -87,5 +86,4 @@ TEST_CASE("[SceneTree][PlaybackStats] Stats Modification and Retrieval") {
 	CHECK(stats->jitter_buffer_max_size == 5);
 	CHECK(Math::is_equal_approx(stats->playback_skips, 10.5));
 }
-
 } // namespace TestPlaybackStats

--- a/tests/test_speech.h
+++ b/tests/test_speech.h
@@ -46,7 +46,6 @@
 #include "tests/test_macros.h"
 
 namespace TestSpeech {
-
 TEST_CASE("[SceneTree][Speech] Initialization and Default Properties") {
 	Speech *speech_node = memnew(Speech);
 	REQUIRE(speech_node != nullptr);
@@ -167,5 +166,4 @@ TEST_CASE("[SceneTree][Speech] Recording Control and Stream Player (No Crash)") 
 	speech_node->set_audio_input_stream_player(nullptr);
 	memdelete(speech_node);
 }
-
 } // namespace TestSpeech

--- a/tests/test_speech.h
+++ b/tests/test_speech.h
@@ -86,7 +86,7 @@ TEST_CASE("[SceneTree][Speech] Property Getters and Setters") {
 	CHECK(speech_node->get_jitter_buffer_slowdown() == 5);
 
 	speech_node->set_debug(true);
-	CHECK(speech_node->get_debug() == true);
+	CHECK(speech_node->get_debug());
 
 	memdelete(speech_node);
 }

--- a/tests/test_speech_decoder.h
+++ b/tests/test_speech_decoder.h
@@ -38,7 +38,6 @@
 #include "tests/test_macros.h"
 
 namespace TestSpeechDecoder {
-
 TEST_CASE("[SpeechDecoder] Initialization") {
 	Ref<SpeechDecoder> decoder = memnew(SpeechDecoder);
 	REQUIRE(decoder.is_valid());
@@ -72,5 +71,4 @@ TEST_CASE("[SpeechDecoder] Process Empty or Invalid Input") {
 			SpeechProcessor::SPEECH_SETTING_BUFFER_FRAME_COUNT);
 	CHECK_MESSAGE(result == OPUS_INVALID_PACKET, "Processing with too small output buffer should return OPUS_INVALID_PACKET.");
 }
-
 } // namespace TestSpeechDecoder

--- a/tests/test_speech_processor.h
+++ b/tests/test_speech_processor.h
@@ -41,7 +41,6 @@
 #include "tests/test_macros.h"
 
 namespace TestSpeechProcessor {
-
 TEST_CASE("[SceneTree][SpeechProcessor] Initialization and Basic Getters") {
 	SpeechProcessor *processor = memnew(SpeechProcessor);
 	REQUIRE(processor != nullptr);
@@ -187,5 +186,4 @@ TEST_CASE("[SpeechProcessor] Test Direct Audio Processing via test_process_mono_
 
 	memdelete(processor);
 }
-
 } // namespace TestSpeechProcessor


### PR DESCRIPTION
## Summary

CHI-101 Phase A — port the TOOL_cloth_dynamics Lean → LeanSlang → slangc bit-exact-validator methodology to godot-speech, formalize four speech kernels, and apply the first concrete diff finding (F1).

## What lands

**Lean kernels** (`lean/Speech/SlangCodegen/*.lean`), each with `native_decide`-pinned emit and `tests/slang_validate/<name>_test.cpp` bit-exact harness:

- `FrameEnergy` — Σx² per 480-sample 10ms frame at 48 kHz (one thread per frame).
- `FramingCursor` — capture-buffer framing-cursor integer divmod policy (single-thread sequential, stateIO carry).
- `JitterAppend` — receive-side jitter-buffer evolution from `on_received_audio_packet` (eight oracle cases).
- `VadGate` — hysteresis state machine for the Silero VAD score stream (enter/exit thresholds + hangover).

All four pass three orthogonal checks at build time:

| Layer | Check |
|---|---|
| Lean | `LeanSlang.emit shader = expected` via `native_decide` |
| C++  | `slangc -target cpp` emit + hand-written CPU reference, **bit-exact (0 ULP)** |
| Discipline | `slangc -target metal` → `xcrun metal` → `.metallib` builds clean (never dispatched at runtime) |

## Findings

- **F1** (`speech_processor.cpp:130`): the capture-loop framing math used `offset < count - frameSize` with `uint32_t` subtraction. Underflows to ~4 G when the resampler returns < 480 samples (first-tick / underrun) → out-of-bounds read past the 8192-element buffer. Strict `<` also silently drops a frame on exact-multiple boundaries. **Fixed**: integer divmod matching the `FramingCursor` Lean spec. The validator demonstrates 5 concrete divergence cases and stays in tree as a regression guard.

  Corroborating: `speech_processor.cpp:401` (the analogous loop in `test_process_mono_audio_frames`) already used the safe `offset + frameSize <= count` form. The codebase had quietly diverged — test path correct, production path wrong, existing tests never reaching the production path.

- **F2** (informational, no fix in this PR): `JITTER_BUFFER_SPEEDUP`, `JITTER_BUFFER_SLOWDOWN`, `STREAM_STANDARD_PITCH`, `STREAM_SPEEDUP_PITCH` are exposed via `ADD_PROPERTY` but never read in any decision-logic code path. Either fold into Phase B step 11 (push-to-talk + open-mic toggles) or remove to avoid silent misconfiguration. Documented in `manuals/decisions/2026-05-12-speech-isolation.md` § F2.

## Methodology

Mirrors TOOL_cloth_dynamics' Lean → LeanSlang → slangc-cpp validator pattern verbatim. Upstream-pinned components (libopus internals, libsamplerate internals, Silero ML weights, whisper.cpp transcription) stay outside the boundary — only V-Sekai-side deterministic bits get the formal treatment. Full rationale + diff-finding workflow in `manuals/decisions/2026-05-12-speech-isolation.md`.

## Test plan

- [x] `lake build Speech` — all four `native_decide` pins pass
- [x] `lake build emit_shaders` — exe builds
- [x] `make -C tests/slang_validate test` with `SLANGC=/path/to/slangc` — all four validators green on cpp + metal targets
- [x] `bash .github/workflows/scripts/clang_format.sh` — clean
- [x] `bash .github/workflows/scripts/file_format.sh` — clean

Local validator output:
```
frame_energy:   3/3 frames OK (max_abs_diff=0)
framing_cursor: 14 ticks OK + 5 bug-demo diffs vs speech_processor.cpp:130
jitter_append:  8/8 events OK (kernel vs ref/oracle/split + final state)
vad_gate:       20/20 frames OK (one-shot, ref, oracle, split, all match)
all kernels OK (cpp target)
all kernels OK (metal target — discipline build)
```

## Out of scope

PcmFromS16 / PcmToS16 kernels (encode/decode side) and the round-trip-asymmetry finding (F3) are in-flight on local but lack their validator harness — deferred to a follow-up PR.