### PR TITLE
CHI-101 Phase A: pin Dear ImGui v1.92.8 as networking test UI

### DIFF
--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -371,6 +371,65 @@ another QUIC stack, while keeping the test outside the Godot build
 matrix per the standard above. Implementation is a separate work
 item — this entry only documents the basis and direction.
 
+### Test UI — Dear ImGui
+
+The standalone networking-test binary uses [Dear ImGui](https://github.com/ocornut/imgui)
+(`ocornut/imgui`) as its UI layer. Pin against tag **v1.92.8** (released
+2026-05-12). Rationale:
+
+* **Godot-free.** ImGui has no dependency on a scene graph or engine
+  runtime — it's a single-header-style C++ library that renders against
+  a graphics backend you choose. Keeps the test binary outside the
+  Godot build matrix per the standard above.
+* **Immediate-mode is right for developer tools.** The whole UI is
+  state-driven from the test driver each frame; no widget tree to
+  manage means a tight loop between network state and what's on
+  screen. Good fit for live-tweaking RTT/jitter/loss profiles and
+  watching the jitter-buffer-depth, energy, and VAD-gate signals
+  evolve in real time.
+* **Cross-platform without effort.** Provided imgui_impl_glfw +
+  imgui_impl_opengl3 (or sdl2/vulkan if Steam Audio later prefers a
+  different backend) build clean on macOS, Linux, and Windows from
+  the same source tree.
+
+**Test UI surface (sketch):**
+
+* **Network profile** — sliders for RTT, jitter σ, datagram loss %,
+  reorder window. Buttons for `LAN` / `WAN` / `Trans-Pacific` /
+  `GEO Satellite` presets matching the F4 routing table.
+* **Live signals** — line charts for jitter-buffer fill depth,
+  per-frame energy from `FrameEnergy`, gated boolean from `VadGate`,
+  packets-emitted-per-tick from `FramingCursor`.
+* **Counters** — `received / decoded / blank-pushed / dropped` per
+  peer; sequence-ID gaps; current carry from the framing cursor;
+  current jitter-buffer carry-state (`currentSeq`, `currentSize`)
+  from `JitterAppend`.
+* **Per-kernel Lean-vs-runtime divergence indicator** — if a
+  validator's slang_validate harness disagrees with the live
+  kernel output on the same input, light up the corresponding
+  kernel row.
+
+Library + backend layout (planned):
+
+```
+tests/net_loopback/                       # new top-level test binary
+├── main.cpp                              # ImGui frame loop + test driver
+├── ui_*.cpp                              # one UI surface per kernel/signal
+├── thirdparty/imgui/                     # vendored ImGui v1.92.8
+│   ├── imgui.{h,cpp}                     # core
+│   ├── imgui_demo.cpp                    # demo (debug aid; not always linked)
+│   ├── imgui_draw.cpp, imgui_widgets.cpp,
+│   │   imgui_tables.cpp
+│   ├── backends/imgui_impl_glfw.{h,cpp}
+│   └── backends/imgui_impl_opengl3.{h,cpp}
+└── thirdparty/picoquic_wrapper/          # slim non-Godot wrapper
+                                          #   pulled from V-Sekai-fire's http3 module
+```
+
+`ImPlot` (`epezent/implot`) is the natural follow-up if the line
+charts get fiddly with raw ImGui — defer that pick until the basic
+UI is up.
+
 ## Other hypotheses still open
 
 * **Capture ring-buffer accounting.** `capture_discarded_frames` /


### PR DESCRIPTION
## Summary

Docs-only update extending PR #15's plan with the UI-layer pick: use [Dear ImGui](https://github.com/ocornut/imgui) (`ocornut/imgui` v1.92.8, released 2026-05-12) as the immediate-mode UI for the standalone networking test binary.

## Why ImGui

- **Godot-free** — single-header-style C++; no scene-graph or engine runtime; keeps the test outside the Godot build matrix per the Phase A standard.
- **Immediate-mode fits a developer tool** — the whole UI is state-driven from the test driver each frame, so the loop between network state and screen is tight.
- **Cross-platform with the standard backends** — `imgui_impl_glfw` + `imgui_impl_opengl3` build clean on macOS, Linux, Windows from the same source tree.

## Test UI surface (sketch)

- **Network profile** — sliders for RTT, jitter σ, datagram loss %, reorder window; presets matching the F4 routing table (LAN / WAN / Trans-Pacific / GEO Satellite).
- **Live signals** — line charts for jitter-buffer fill depth, per-frame energy from `FrameEnergy`, gated boolean from `VadGate`, packets-emitted-per-tick from `FramingCursor`.
- **Counters** — received / decoded / blank-pushed / dropped per peer; sequence-ID gaps; current carry from the framing cursor; current jitter-buffer carry-state from `JitterAppend`.
- **Per-kernel divergence indicator** — if a slang_validate harness disagrees with the live kernel on the same input, light up the corresponding row.

Directory layout (planned, in this PR's doc body):

```
tests/net_loopback/
├── main.cpp                    # ImGui frame loop + test driver
├── ui_*.cpp                    # one UI surface per kernel/signal
├── thirdparty/imgui/           # vendored ImGui v1.92.8
│   ├── imgui.{h,cpp}, imgui_demo.cpp, imgui_draw.cpp,
│   │   imgui_widgets.cpp, imgui_tables.cpp
│   └── backends/imgui_impl_glfw.{h,cpp}, imgui_impl_opengl3.{h,cpp}
└── thirdparty/picoquic_wrapper/   # slim non-Godot wrapper from http3 module
```

`ImPlot` deferred as a follow-up if raw ImGui plots become limiting.

## Out of scope

Implementation. This PR only pins the library + version and records the planned shape.

## Test plan

- [x] `clang_format.sh` — clean
- [x] `file_format.sh` — clean