### PR TITLE
CHI-101 Phase A: PCM s16↔float kernels + F3 round-trip asymmetry pinning

### DIFF
--- a/lean/EmitShaders.lean
+++ b/lean/EmitShaders.lean
@@ -21,6 +21,8 @@ private def kernels : List (String × SlangShaderModule) :=
   [ ("frame_energy",    FrameEnergy.shader)
   , ("framing_cursor",  FramingCursor.shader)
   , ("jitter_append",   JitterAppend.shader)
+  , ("pcm_from_s16",    PcmFromS16.shader)
+  , ("pcm_to_s16",      PcmToS16.shader)
   , ("vad_gate",        VadGate.shader)
   ]
 

--- a/lean/Speech/SlangCodegen.lean
+++ b/lean/Speech/SlangCodegen.lean
@@ -1,6 +1,8 @@
 import Speech.SlangCodegen.FrameEnergy
 import Speech.SlangCodegen.FramingCursor
 import Speech.SlangCodegen.JitterAppend
+import Speech.SlangCodegen.PcmFromS16
+import Speech.SlangCodegen.PcmToS16
 import Speech.SlangCodegen.VadGate
 
 /-!

--- a/lean/Speech/SlangCodegen/PcmFromS16.lean
+++ b/lean/Speech/SlangCodegen/PcmFromS16.lean
@@ -1,0 +1,103 @@
+import LeanSlang
+
+/-!
+# `Speech.SlangCodegen.PcmFromS16` — int16 PCM → float32 in [-1, 1)
+
+CHI-101 Phase A. Mirrors `SpeechProcessor::_16_pcm_mono_to_real_stereo`
+(`speech_processor.cpp:200`), which is the receive-side decode of a
+mono int16 PCM packet into the float32 stereo audio that
+`AudioStreamGeneratorPlayback::push_buffer` consumes.
+
+Formula:
+
+  out[i] = (float)s16[i] / 32768.0f
+
+Range: s16 ∈ [-32768, +32767] maps to float ∈ [-1.0, +0.999969...).
+The asymmetry with the encode kernel (`PcmToS16`, which uses
+`* 32767.0f`) is recorded as informational finding F3 in
+`manuals/decisions/2026-05-12-speech-isolation.md`.
+
+This kernel is the **mono → mono** half — the duplicate-to-stereo
+expansion in the C++ is a trivial copy that doesn't need its own
+kernel. Callers can either:
+  * Run this kernel + a separate stereo-expand (write L=R=value
+    via a `RWStructuredBuffer<float2>` output), or
+  * Write the receiver-side HRTF stack on top of mono and let
+    Steam Audio handle spatialization at the listener.
+
+CHI-101 picks the second option (Steam Audio receives mono, places
+it at the sender's head pose), so we only need mono output here.
+
+One thread per output sample. Bit-exact bound: the result is
+`(float)(s16) / 32768.0f` which is exact under IEEE 754 round-to-
+nearest because 32768 is a power of two; the division is just a
+binary-exponent shift.
+
+## Bindings (set 0)
+
+  0  ConstantBuffer<PcmFromS16Params> { uint numSamples; }
+  1  StructuredBuffer<int>     samplesIn      length = numSamples  (int16 zero-or-sign-extended to int32)
+  2  RWStructuredBuffer<float> samplesOut     length = numSamples
+-/
+
+namespace Speech.SlangCodegen.PcmFromS16
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+private def intTy   : SlangType := .scalar .int
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "PcmFromS16Params"
+        , fields := [⟨"numSamples", uintTy, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params",     .const "PcmFromS16Params", Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"samplesIn",  .roBuf intTy,              Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"samplesOut", .rwBuf floatTy,            Semantic.none, some 2, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit uintTy "i" (.member (.var "tid") "x")
+        , .ifNoElse (.bin ">=" (.var "i") (.member (.var "params") "numSamples"))
+            [ .ret none ]
+        , .assign (.index (.var "samplesOut") (.var "i"))
+            (.bin "/"
+              (.call "float" [.index (.var "samplesIn") (.var "i")])
+              (.litFloat 32768.0))
+        ] }] }
+
+/-- Pinned reference emission. Drift in `LeanSlang.Emit` that affects
+    this output trips `native_decide` below. Regenerate after a deliberate
+    change via `lake exe emit_shaders /tmp/emit && cat /tmp/emit/pcm_from_s16.slang`. -/
+def expected : String :=
+"struct PcmFromS16Params {
+  uint numSamples;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<PcmFromS16Params> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<int> samplesIn;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<float> samplesOut;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  if ((i >= params.numSamples)) {
+    return;
+  }
+  samplesOut[i] = (float(samplesIn[i]) / 32768.000000);
+}"
+
+/-- The pretty-printer matches the pinned reference. -/
+example : LeanSlang.emit shader = expected := by native_decide
+
+/-- The kernel's entry-point name is `main`. -/
+example : shader.entryPointName = "main" := by native_decide
+
+end Speech.SlangCodegen.PcmFromS16

--- a/lean/Speech/SlangCodegen/PcmToS16.lean
+++ b/lean/Speech/SlangCodegen/PcmToS16.lean
@@ -1,0 +1,113 @@
+import LeanSlang
+
+/-!
+# `Speech.SlangCodegen.PcmToS16` — float32 [-1, 1] → int16 PCM (encode)
+
+CHI-101 Phase A. Mirrors the inner loop inside
+`SpeechProcessor::_mix_audio` (`speech_processor.cpp:131-135`),
+which converts a float32 PCM frame into the int16 little-endian
+buffer that gets handed to Opus.
+
+Formula (matching the C++ literally, including the asymmetric scale):
+
+  scaled = sample * 32767.0f
+  clamped = max(-32768.0f, min(32767.0f, scaled))
+  out[i] = (int)clamped
+
+Notes on the asymmetry vs. the decode side (`PcmFromS16` uses
+`/ 32768.0f`):
+
+  * `1.0f * 32767 = 32767` → fits in int16, no clamp needed.
+  * `-1.0f * 32767 = -32767` → fits, but the *minimum representable*
+    int16 (-32768) is never produced by this encoder. The clamp's
+    lower bound of -32768 only fires for floats below -1.0.
+  * The round-trip `1.0f -> PcmToS16 -> PcmFromS16` produces
+    `32767 / 32768 = 0.999969...`, not `1.0f`. A ~0.000266 dB gain
+    reduction on full-scale signals.
+
+Whether this is desired is a design question, not a correctness
+question — both `* 32767` (Q15 with symmetric clamp) and `* 32768`
+(asymmetric, requires explicit `1.0` overflow handling) are valid
+PCM conventions. We pin the current C++ choice as the spec and
+record the asymmetry in the decision doc (F3, informational).
+
+One thread per output sample. The clamp uses `max`/`min` rather
+than a CLAMP macro because Slang exposes both as intrinsics with
+well-defined IEEE 754 behavior for NaN inputs (returns the
+non-NaN argument).
+
+## Bindings (set 0)
+
+  0  ConstantBuffer<PcmToS16Params> { uint numSamples; }
+  1  StructuredBuffer<float> samplesIn      length = numSamples
+  2  RWStructuredBuffer<int> samplesOut     length = numSamples  (int16 zero-or-sign-extended to int32)
+-/
+
+namespace Speech.SlangCodegen.PcmToS16
+
+open LeanSlang
+
+private def floatTy : SlangType := .scalar .float
+private def uintTy  : SlangType := .scalar .uint
+private def intTy   : SlangType := .scalar .int
+
+def shader : SlangShaderModule :=
+  { structs :=
+      [ { name := "PcmToS16Params"
+        , fields := [⟨"numSamples", uintTy, Semantic.none, none, none, .qIn⟩] } ]
+  , globals :=
+      [ ⟨"params",     .const "PcmToS16Params", Semantic.none, some 0, some 0, .qIn⟩
+      , ⟨"samplesIn",  .roBuf floatTy,          Semantic.none, some 1, some 0, .qIn⟩
+      , ⟨"samplesOut", .rwBuf intTy,            Semantic.none, some 2, some 0, .qIn⟩ ]
+  , functions := [{
+      attrs  := [.shaderCompute, .numthreads 64 1 1]
+      name   := "main"
+      params := [⟨"tid", .vec .uint 3, .svDispatchThreadId, none, none, .qIn⟩]
+      body   :=
+        [ .declInit uintTy "i" (.member (.var "tid") "x")
+        , .ifNoElse (.bin ">=" (.var "i") (.member (.var "params") "numSamples"))
+            [ .ret none ]
+        , .declInit floatTy "s"
+            (.bin "*" (.index (.var "samplesIn") (.var "i")) (.litFloat 32767.0))
+        , .declInit floatTy "lo"
+            (.call "max" [.un "-" (.litFloat 32768.0), .var "s"])
+        , .declInit floatTy "c"
+            (.call "min" [.litFloat 32767.0, .var "lo"])
+        , .assign (.index (.var "samplesOut") (.var "i"))
+            (.call "int" [.var "c"])
+        ] }] }
+
+/-- Pinned reference emission. Drift in `LeanSlang.Emit` that affects
+    this output trips `native_decide` below. Regenerate after a deliberate
+    change via `lake exe emit_shaders /tmp/emit && cat /tmp/emit/pcm_to_s16.slang`. -/
+def expected : String :=
+"struct PcmToS16Params {
+  uint numSamples;
+};
+
+[[vk::binding(0, 0)]]
+ConstantBuffer<PcmToS16Params> params;
+[[vk::binding(1, 0)]]
+StructuredBuffer<float> samplesIn;
+[[vk::binding(2, 0)]]
+RWStructuredBuffer<int> samplesOut;
+
+[shader(\"compute\")] [numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  uint i = tid.x;
+  if ((i >= params.numSamples)) {
+    return;
+  }
+  float s = (samplesIn[i] * 32767.000000);
+  float lo = max((-32768.000000), s);
+  float c = min(32767.000000, lo);
+  samplesOut[i] = int(c);
+}"
+
+/-- The pretty-printer matches the pinned reference. -/
+example : LeanSlang.emit shader = expected := by native_decide
+
+/-- The kernel's entry-point name is `main`. -/
+example : shader.entryPointName = "main" := by native_decide
+
+end Speech.SlangCodegen.PcmToS16

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -13,6 +13,7 @@ methodology, and outstanding questions; it will be the artifact CHI-101 Step 6 e
 | 2    | Lean spec: frame energy (VAD fallback signal)       | done         |
 | 2    | Lean spec: framing cursor (capture-loop policy)     | done         |
 | 2    | Lean spec: jitter-buffer append (receive-side)      | done         |
+| 2    | Lean spec: PCM s16↔float (encode + decode)          | done         |
 | 2    | Lean spec: PCM framing / resampling (full)          | partial      |
 | 2    | Lean spec: Opus encode/decode invariants            | not started  |
 | 2    | Lean spec: jitter buffer sizing (C5 from PredictiveBVH) | done     |
@@ -231,6 +232,38 @@ forward-by-1) and the kernel matches both the CPU reference and the
 hand-checked oracle frame-for-frame. The `on_received_audio_packet` math
 in `speech.cpp` is *correct* — it doesn't have an F1-style bug. The kernel
 stays in tree as a regression guard for any future edits to the receive path.
+
+### F3. PCM s16↔float round-trip gain is asymmetric (informational)
+
+**Status:** pinned by `tests/slang_validate/pcm_roundtrip_test.cpp`. **No
+fix recommended** — design choice not a bug — but the asymmetry is now
+formally pinned so future review can revisit with a concrete number.
+
+The encode side (`PcmToS16`, mirroring the inner loop of
+`SpeechProcessor::_mix_audio`) multiplies by **32767** with a clamp to
+`[-32768, +32767]`. The decode side (`PcmFromS16`, mirroring
+`SpeechProcessor::_16_pcm_mono_to_real_stereo`) divides by **32768**.
+Round-tripping `1.0f` produces `0.9999695...`, not `1.0f`:
+
+```
+pcm_roundtrip: encode/decode asymmetry sweep (N=65):
+  max |err|          = 3.051758e-05  (theoretical at x=+1: 3.051758e-05)
+  max signed err     = +3.051758e-05
+  round-trip gain    = 0.999969 (= 32767/32768; -0.0003 dB)
+```
+
+Both `* 32767` (Q15 with symmetric clamp; this codebase's choice) and
+`* 32768` (true 1-LSB-per-step encode; requires explicit overflow
+handling for input == 1.0) are valid PCM conventions. `* 32767`
+trades the unreachable `-32768` int16 value for a clamp-safe encoder
+that handles `1.0f` exactly without overflow. -0.0003 dB of round-trip
+gain is well below human-audible threshold (typical JND is ~0.5 dB).
+
+The validator pins the gain at exactly `32767/32768` and fails if the
+round-trip of `1.0f` ever returns something else. If a future refactor
+adopts `* 32768` (e.g. for tighter Bit-Exact-When-Possible
+interoperation with other PCM libraries), the validator will trip and
+require the decision to be revisited explicitly.
 
 ### F4. C5 / G181 (PredictiveBVH gap class) — voice jitter buffer too shallow for WAN RTT
 

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -24,7 +24,13 @@ REPO_ROOT  := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
 SLANGC     ?= slangc
 EMITTED    := $(CURDIR)/build
 LEAN_DIR   := $(REPO_ROOT)/lean
-SLANG_INC  := $(abspath $(dir $(SLANGC))/../include)
+# Slang's cpp prelude header lives next to the slangc binary tree.
+# Try $(SLANGC_DIR)/.slang/include first (wrapper-script layout used by
+# cloth_dynamics' bin/slangc), fall back to $(SLANGC_DIR)/../include
+# (raw-binary layout).
+SLANG_INC  := $(firstword \
+                $(wildcard $(dir $(SLANGC)).slang/include) \
+                $(abspath $(dir $(SLANGC))/../include))
 
 CXX        ?= clang++
 # -Wno-unused-parameter silences clang's complaint about
@@ -37,10 +43,12 @@ INCLUDES   := -I$(SLANG_INC) -I$(EMITTED)
 TESTS      := frame_energy:frame_energy \
               framing_cursor:framing_cursor \
               jitter_append:jitter_append \
+              pcm_from_s16:pcm_from_s16 \
+              pcm_to_s16:pcm_to_s16 \
               vad_gate:vad_gate
 
 # Metal kernels (discipline build; never run at runtime).
-METAL_KERNELS := frame_energy framing_cursor jitter_append vad_gate
+METAL_KERNELS := frame_energy framing_cursor jitter_append pcm_from_s16 pcm_to_s16 vad_gate
 METALLIBS     := $(addprefix $(EMITTED)/,$(addsuffix .metallib,$(METAL_KERNELS)))
 
 TEST_NAMES := $(foreach t,$(TESTS),$(word 1,$(subst :, ,$(t))))
@@ -84,6 +92,19 @@ $(EMITTED)/%_emit.cpp: emit-shaders
 .SECONDEXPANSION:
 $(EMITTED)/%_test: %_test.cpp $$(EMITTED)/$$(call KERNEL_FOR,%)_emit.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -o $@ $<
+
+# Multi-kernel composition: pcm_roundtrip co-includes both PCM emits
+# via the namespace + SLANG_PRELUDE_EXTERN_C-undef pattern (see
+# tests/slang_validate/pcm_roundtrip_test.cpp header comment, and
+# cloth_dynamics' cg_demo_test.cpp for the original pattern).
+$(EMITTED)/pcm_roundtrip_test: pcm_roundtrip_test.cpp \
+                               $(EMITTED)/pcm_to_s16_emit.cpp \
+                               $(EMITTED)/pcm_from_s16_emit.cpp
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -I$(SLANG_INC) -o $@ $<
+
+# Add pcm_roundtrip to the test list (not in TESTS because it depends
+# on multiple kernels, but we still want `make test` to run it).
+BINS       += $(EMITTED)/pcm_roundtrip_test
 
 # ---- Metal discipline pipeline ----------------------------------------
 # slang -> .metal source -> .air -> .metallib. xcrun-only; skip on non-macOS.

--- a/tests/slang_validate/pcm_from_s16_test.cpp
+++ b/tests/slang_validate/pcm_from_s16_test.cpp
@@ -1,0 +1,77 @@
+// Real-input validator for Speech.SlangCodegen.PcmFromS16.
+//
+// Reference: lean/Speech/SlangCodegen/PcmFromS16.lean. Mirrors
+// SpeechProcessor::_16_pcm_mono_to_real_stereo (speech_processor.cpp):
+//
+//   out[i] = (float)s16[i] / 32768.0f
+//
+// Bit-exact: dividing by 32768 (a power of two) is an exact
+// binary-exponent shift in IEEE 754, and `(float)(int32_t)` is
+// deterministic for values within the s16 range. Round-trip 1 ULP
+// concerns belong to pcm_roundtrip_test, not here.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+
+#include "pcm_from_s16_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+static float ref_decode(std::int32_t s) {
+	return static_cast<float>(s) / 32768.0f;
+}
+
+int main() {
+	const auto t0 = std::chrono::steady_clock::now();
+
+	const std::int32_t in[] = {
+		0, 1, -1, 16384, -16384, 32767, -32767, -32768, 12345
+	};
+	constexpr std::uint32_t N = sizeof(in) / sizeof(in[0]);
+	constexpr std::uint32_t GROUP_SIZE = 64;
+	static_assert(N <= GROUP_SIZE, "fixture must fit in one thread group");
+
+	float kernel_out[GROUP_SIZE] = {};
+
+	PcmFromS16Params_0 params{ N };
+	GlobalParams_0 gp{};
+	gp.params_0 = &params;
+	gp.samplesIn_0.data = const_cast<std::int32_t *>(in);
+	gp.samplesIn_0.count = N;
+	gp.samplesOut_0.data = kernel_out;
+	gp.samplesOut_0.count = GROUP_SIZE;
+
+	ComputeVaryingInput vi{};
+	vi.startGroupID = uint3(0, 0, 0);
+	vi.endGroupID = uint3(1, 1, 1);
+	main_0(&vi, nullptr, &gp);
+
+	int fails = 0;
+	for (std::uint32_t i = 0; i < N; ++i) {
+		const float ref = ref_decode(in[i]);
+		if (kernel_out[i] != ref) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"pcm_from_s16 mismatch at i=%u: in=%d got=%g ref=%g\n",
+						i, in[i], kernel_out[i], ref);
+			}
+			++fails;
+		}
+	}
+
+	const auto t1 = std::chrono::steady_clock::now();
+	const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+	if (elapsed > kBudgetSeconds) {
+		std::fprintf(stderr, "pcm_from_s16: TIMEOUT — %.3fs > %.1fs\n",
+				elapsed, kBudgetSeconds);
+		return 2;
+	}
+	if (fails == 0) {
+		std::printf("pcm_from_s16: %u/%u samples OK (decode; %.1fms)\n",
+				N, N, elapsed * 1000.0);
+		return 0;
+	}
+	std::fprintf(stderr, "pcm_from_s16: %d FAIL\n", fails);
+	return 1;
+}

--- a/tests/slang_validate/pcm_roundtrip_test.cpp
+++ b/tests/slang_validate/pcm_roundtrip_test.cpp
@@ -1,0 +1,165 @@
+// Round-trip composition validator for
+//   Speech.SlangCodegen.PcmToS16  (encode: * 32767, clamp, cast)
+//   Speech.SlangCodegen.PcmFromS16 (decode: cast, / 32768)
+//
+// Two slangc-cpp emits in one translation unit — both define `main_0`
+// and `GlobalParams_0` at file scope, so we follow the cloth_dynamics
+// `cg_demo_test.cpp` pattern: include each emit inside its own
+// namespace, with SLANG_PRELUDE_EXTERN_C macros temporarily neutered
+// so the kernel symbols respect the surrounding namespace.
+//
+// The harness:
+//   1. Encodes a sweep of float inputs across [-1, 1].
+//   2. Decodes the resulting s16 values back to float.
+//   3. Quantifies the deviation. The asymmetric scale on the two sides
+//      (32767 encode, 32768 decode) produces a known round-trip gain
+//      of 32767/32768 ≈ -0.000266 dB. Recorded in the decision doc as
+//      informational finding F3 — not a bug, but pinned so future
+//      review can revisit the choice with a concrete number.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "slang-cpp-prelude.h"
+
+namespace rt_to {
+#pragma push_macro("SLANG_PRELUDE_EXTERN_C")
+#pragma push_macro("SLANG_PRELUDE_EXTERN_C_START")
+#pragma push_macro("SLANG_PRELUDE_EXTERN_C_END")
+#undef SLANG_PRELUDE_EXTERN_C
+#undef SLANG_PRELUDE_EXTERN_C_START
+#undef SLANG_PRELUDE_EXTERN_C_END
+#define SLANG_PRELUDE_EXTERN_C
+#define SLANG_PRELUDE_EXTERN_C_START
+#define SLANG_PRELUDE_EXTERN_C_END
+#include "pcm_to_s16_emit.cpp"
+#pragma pop_macro("SLANG_PRELUDE_EXTERN_C")
+#pragma pop_macro("SLANG_PRELUDE_EXTERN_C_START")
+#pragma pop_macro("SLANG_PRELUDE_EXTERN_C_END")
+} // namespace rt_to
+
+namespace rt_from {
+#pragma push_macro("SLANG_PRELUDE_EXTERN_C")
+#pragma push_macro("SLANG_PRELUDE_EXTERN_C_START")
+#pragma push_macro("SLANG_PRELUDE_EXTERN_C_END")
+#undef SLANG_PRELUDE_EXTERN_C
+#undef SLANG_PRELUDE_EXTERN_C_START
+#undef SLANG_PRELUDE_EXTERN_C_END
+#define SLANG_PRELUDE_EXTERN_C
+#define SLANG_PRELUDE_EXTERN_C_START
+#define SLANG_PRELUDE_EXTERN_C_END
+#include "pcm_from_s16_emit.cpp"
+#pragma pop_macro("SLANG_PRELUDE_EXTERN_C")
+#pragma pop_macro("SLANG_PRELUDE_EXTERN_C_START")
+#pragma pop_macro("SLANG_PRELUDE_EXTERN_C_END")
+} // namespace rt_from
+
+static constexpr double kBudgetSeconds = 5.0;
+
+int main() {
+	const auto t0 = std::chrono::steady_clock::now();
+
+	// 65 sweep points across [-1, 1] inclusive.
+	constexpr std::uint32_t N = 65;
+	// Two thread groups cover 128 lanes; N = 65 fits with room for the
+	// numSamples early-return on the spare 63 lanes.
+	float in[N];
+	for (std::uint32_t i = 0; i < N; ++i) {
+		in[i] = -1.0f + 2.0f * static_cast<float>(i) / (N - 1);
+	}
+
+	// Pad input/output buffers so both groups can write safely.
+	float in_pad[128] = {};
+	std::int32_t encoded[128] = {};
+	float decoded[128] = {};
+	for (std::uint32_t i = 0; i < N; ++i)
+		in_pad[i] = in[i];
+
+	// ---- Encode dispatch.
+	{
+		rt_to::PcmToS16Params_0 p{ N };
+		rt_to::GlobalParams_0 gp{};
+		gp.params_0 = &p;
+		gp.samplesIn_0.data = in_pad;
+		gp.samplesIn_0.count = 128;
+		gp.samplesOut_0.data = encoded;
+		gp.samplesOut_0.count = 128;
+		ComputeVaryingInput vi{};
+		vi.startGroupID = uint3(0, 0, 0);
+		vi.endGroupID = uint3(2, 1, 1); // two groups of 64
+		rt_to::main_0(&vi, nullptr, &gp);
+	}
+
+	// ---- Decode dispatch.
+	{
+		rt_from::PcmFromS16Params_0 p{ N };
+		rt_from::GlobalParams_0 gp{};
+		gp.params_0 = &p;
+		gp.samplesIn_0.data = encoded;
+		gp.samplesIn_0.count = 128;
+		gp.samplesOut_0.data = decoded;
+		gp.samplesOut_0.count = 128;
+		ComputeVaryingInput vi{};
+		vi.startGroupID = uint3(0, 0, 0);
+		vi.endGroupID = uint3(2, 1, 1);
+		rt_from::main_0(&vi, nullptr, &gp);
+	}
+
+	// ---- Quantify the asymmetry.
+	float max_abs_err = 0.0f;
+	float max_signed_err = 0.0f;
+	for (std::uint32_t i = 0; i < N; ++i) {
+		const float err = decoded[i] - in[i];
+		if (std::fabs(err) > std::fabs(max_signed_err))
+			max_signed_err = err;
+		if (std::fabs(err) > max_abs_err)
+			max_abs_err = std::fabs(err);
+	}
+
+	const float expected_max_at_unity = 1.0f - 32767.0f / 32768.0f;
+
+	std::printf("pcm_roundtrip: encode/decode asymmetry sweep (N=%u):\n", N);
+	std::printf("  max |err|          = %.7g  (theoretical at x=+1: %.7g)\n",
+			max_abs_err, expected_max_at_unity);
+	std::printf("  max signed err     = %+.7g\n", max_signed_err);
+	std::printf("  round-trip gain    = %.6f (= 32767/32768; %.4f dB)\n",
+			32767.0f / 32768.0f,
+			20.0 * std::log10(32767.0 / 32768.0));
+
+	int fails = 0;
+	// Sanity: max error must be bounded by 1/32767 (quantization +
+	// asymmetric gain). Bigger error is a bug, not the documented F3.
+	if (max_abs_err > 1.0f / 32767.0f) {
+		std::fprintf(stderr,
+				"pcm_roundtrip: max_abs_err %.7g exceeds 1/32767 = %.7g — bug?\n",
+				max_abs_err, 1.0f / 32767.0f);
+		++fails;
+	}
+
+	// Also pin: round-trip of 1.0f must be exactly 32767/32768.
+	const float rt_unity = decoded[N - 1]; // last sweep point = +1.0f
+	const float expected_unity = 32767.0f / 32768.0f;
+	if (rt_unity != expected_unity) {
+		std::fprintf(stderr,
+				"pcm_roundtrip: round-trip of 1.0 = %g, expected %g\n",
+				rt_unity, expected_unity);
+		++fails;
+	}
+
+	const auto t1 = std::chrono::steady_clock::now();
+	const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+	if (elapsed > kBudgetSeconds) {
+		std::fprintf(stderr, "pcm_roundtrip: TIMEOUT — %.3fs > %.1fs\n",
+				elapsed, kBudgetSeconds);
+		return 2;
+	}
+	if (fails == 0) {
+		std::printf("pcm_roundtrip: %u sweep points OK; F3 gain pinned at %.6f (%.1fms)\n",
+				N, expected_unity, elapsed * 1000.0);
+		return 0;
+	}
+	std::fprintf(stderr, "pcm_roundtrip: %d FAIL\n", fails);
+	return 1;
+}

--- a/tests/slang_validate/pcm_to_s16_test.cpp
+++ b/tests/slang_validate/pcm_to_s16_test.cpp
@@ -1,0 +1,92 @@
+// Real-input validator for Speech.SlangCodegen.PcmToS16.
+//
+// Reference: lean/Speech/SlangCodegen/PcmToS16.lean. Mirrors the
+// inner loop of SpeechProcessor::_mix_audio (speech_processor.cpp):
+//
+//   scaled  = sample * 32767.0f
+//   clamped = clamp(scaled, -32768.0f, 32767.0f)
+//   out[i]  = (int)clamped
+//
+// The CPU reference uses the same formula, so the comparison is
+// bit-exact: clamp + cast are deterministic under IEEE 754
+// round-toward-zero for the integer conversion. The fixture covers
+// the encode-side edge cases: zero, positive / negative mid-range,
+// the canonical 1.0 / -1.0 endpoints, and over-range inputs that
+// must clamp.
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#include "pcm_to_s16_emit.cpp"
+
+static constexpr double kBudgetSeconds = 5.0;
+
+static std::int32_t ref_encode(float v) {
+	const float scaled = v * 32767.0f;
+	const float clamped = std::fmin(32767.0f, std::fmax(-32768.0f, scaled));
+	return static_cast<std::int32_t>(clamped);
+}
+
+int main() {
+	const auto t0 = std::chrono::steady_clock::now();
+
+	const float in[] = {
+		0.0f, // -> 0
+		0.5f, // -> 16383 (truncation toward zero from 16383.5)
+		-0.5f, // -> -16383
+		1.0f, // -> 32767 (max int16)
+		-1.0f, // -> -32767 (NOT -32768 — encoder can't reach it)
+		1.5f, // -> 32767 (clamp upper)
+		-1.5f, // -> -32768 (clamp lower)
+		1.0f / 32768.0f, // -> 0 (1/32768 * 32767 ≈ 0.99997 → trunc to 0)
+		2.0f / 32768.0f, // -> 1 (2/32768 * 32767 ≈ 1.99994 → trunc to 1)
+	};
+	constexpr std::uint32_t N = sizeof(in) / sizeof(in[0]);
+	constexpr std::uint32_t GROUP_SIZE = 64;
+	static_assert(N <= GROUP_SIZE, "fixture must fit in one thread group");
+
+	std::int32_t kernel_out[GROUP_SIZE] = {};
+
+	PcmToS16Params_0 params{ N };
+	GlobalParams_0 gp{};
+	gp.params_0 = &params;
+	gp.samplesIn_0.data = const_cast<float *>(in);
+	gp.samplesIn_0.count = N;
+	gp.samplesOut_0.data = kernel_out;
+	gp.samplesOut_0.count = GROUP_SIZE;
+
+	ComputeVaryingInput vi{};
+	vi.startGroupID = uint3(0, 0, 0);
+	vi.endGroupID = uint3(1, 1, 1);
+	main_0(&vi, nullptr, &gp);
+
+	int fails = 0;
+	for (std::uint32_t i = 0; i < N; ++i) {
+		const std::int32_t ref = ref_encode(in[i]);
+		if (kernel_out[i] != ref) {
+			if (fails < 5) {
+				std::fprintf(stderr,
+						"pcm_to_s16 mismatch at i=%u: in=%g got=%d ref=%d\n",
+						i, in[i], kernel_out[i], ref);
+			}
+			++fails;
+		}
+	}
+
+	const auto t1 = std::chrono::steady_clock::now();
+	const double elapsed = std::chrono::duration<double>(t1 - t0).count();
+	if (elapsed > kBudgetSeconds) {
+		std::fprintf(stderr, "pcm_to_s16: TIMEOUT — %.3fs > %.1fs\n",
+				elapsed, kBudgetSeconds);
+		return 2;
+	}
+	if (fails == 0) {
+		std::printf("pcm_to_s16: %u/%u samples OK (encode + clamp; %.1fms)\n",
+				N, N, elapsed * 1000.0);
+		return 0;
+	}
+	std::fprintf(stderr, "pcm_to_s16: %d FAIL\n", fails);
+	return 1;
+}


### PR DESCRIPTION
## Summary

Add the two remaining PCM-conversion kernels under Phase A:

- **`PcmToS16`** — float × 32767, clamp to [-32768, 32767], cast to int. Mirrors the inner loop of `SpeechProcessor::_mix_audio`.
- **`PcmFromS16`** — int / 32768.0f. Mirrors `SpeechProcessor::_16_pcm_mono_to_real_stereo`.

Plus a round-trip validator that pins **F3** — the codebase's design choice of asymmetric scales (32767 encode, 32768 decode) produces a known -0.0003 dB round-trip gain. Below human-audible threshold; pinned so any future refactor toward `* 32768` (or anything else) trips the validator and requires the decision to be revisited explicitly.

## Validator output

```
=== pcm_from_s16_test
pcm_from_s16: 9/9 samples OK (decode; 0.0ms)
=== pcm_to_s16_test
pcm_to_s16: 9/9 samples OK (encode + clamp; 0.0ms)
=== pcm_roundtrip_test
pcm_roundtrip: encode/decode asymmetry sweep (N=65):
  max |err|          = 3.051758e-05  (theoretical at x=+1: 3.051758e-05)
  max signed err     = +3.051758e-05
  round-trip gain    = 0.999969 (= 32767/32768; -0.0003 dB)
pcm_roundtrip: 65 sweep points OK; F3 gain pinned at 0.999969
all kernels OK (cpp target)
all kernels OK (metal target — discipline build)
```

## Files

- `lean/Speech/SlangCodegen/PcmToS16.lean`, `PcmFromS16.lean` — kernels with `native_decide`-pinned emit
- `lean/Speech/SlangCodegen.lean`, `lean/EmitShaders.lean` — umbrella registrations
- `tests/slang_validate/pcm_to_s16_test.cpp`, `pcm_from_s16_test.cpp` — per-kernel validators
- `tests/slang_validate/pcm_roundtrip_test.cpp` — composition validator using the cloth_dynamics namespace + EXTERN_C-undef pattern (see file header)
- `tests/slang_validate/Makefile` — adds the three tests, fixes slang prelude include-path derivation for both `bin/slangc` (wrapper) and `bin/.slang/bin/slangc` (raw binary) layouts
- `manuals/decisions/2026-05-12-speech-isolation.md` — F3 entry + status table update

## Out of scope

Independent end-to-end audio-system-model test (separate work item per user direction).

## Test plan

- [x] `lake build Speech` — all six kernels' `native_decide` pins pass
- [x] `make -C tests/slang_validate test` — all seven validators green on cpp + metal targets
- [x] `clang_format.sh` — clean
- [x] `file_format.sh` — clean