### PR TITLE
CHI-101 Phase A: Godot-free CI — slang_validate + audio_model on every PR

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -1,0 +1,87 @@
+name: 🧪 Godot-free CI
+
+# Build verification for the Godot-engine-independent test trees:
+#   * tests/slang_validate/  — Lean-formalized kernels + slangc-cpp + bit-exact CPU validators
+#   * tests/godot_audio_model/  — CMake-built stand-in for Godot's audio API, with the verbatim macOS CoreAudio driver
+#
+# Neither tree links against godot-cpp or the Godot engine; this
+# workflow exists precisely to keep them buildable on every PR
+# touching speech*, lean/, tests/slang_validate/, or
+# tests/godot_audio_model/.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  slang_validate:
+    name: Slang validators (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Lean 4 toolchain via elan. We pin in lean/lean-toolchain
+      # (currently leanprover/lean4:v4.29.1); elan reads it from cwd.
+      - name: Install elan + Lean
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Lake build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lean/.lake
+            ~/.elan/toolchains
+          key: lake-${{ matrix.os }}-${{ hashFiles('lean/lean-toolchain', 'lean/lake-manifest.json') }}
+
+      - name: Build Lean tree (native_decide pins)
+        working-directory: lean
+        run: lake build Speech emit_shaders
+
+      - name: Install slangc (pinned)
+        env:
+          SLANG_HOME: ${{ runner.temp }}/slang
+        run: |
+          bash misc/install-slang.sh "$SLANG_HOME"
+          echo "SLANG_HOME=$SLANG_HOME" >> "$GITHUB_ENV"
+          echo "$SLANG_HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Run slang validators (cpp target — bit-exact)
+        working-directory: tests/slang_validate
+        run: SLANGC="$SLANG_HOME/bin/slangc" make test-cpp
+
+      - name: Run slang validators (metal target — discipline)
+        if: runner.os == 'macOS'
+        working-directory: tests/slang_validate
+        run: SLANGC="$SLANG_HOME/bin/slangc" make metal-discipline
+
+  audio_model_macos:
+    name: Audio model (macOS, CoreAudio)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure CMake
+        working-directory: tests/godot_audio_model
+        run: cmake -S . -B build -G "Unix Makefiles"
+
+      - name: Build
+        working-directory: tests/godot_audio_model
+        run: cmake --build build --parallel
+
+      - name: Smoke test
+        working-directory: tests/godot_audio_model
+        run: ./build/godot_audio_model_smoke

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -361,6 +361,25 @@ require the engine. The math layer should stay independent.
   divergence between it and a Godot-side test is a finding worth
   recording.
 
+**CI coverage:** the `.github/workflows/godot_free_ci.yml` workflow
+runs the Godot-free trees on every PR + main push:
+
+* `Slang validators (ubuntu-latest)` and `Slang validators (macos-latest)` —
+  install Lean via elan, install pinned `slangc` v2026.8.1 via
+  `misc/install-slang.sh`, build the Lean tree (`native_decide`
+  pins), then run `make -C tests/slang_validate test-cpp`. The
+  macOS job additionally runs `metal-discipline` (slangc-metal →
+  xcrun metal → .metallib) so the dual-target discipline check
+  doesn't rot.
+* `Audio model (macOS, CoreAudio)` — `cmake --build` the
+  `tests/godot_audio_model/` tree on macOS (including the verbatim
+  CoreAudio driver) and run the smoke test.
+
+No `godot-cpp`, no Godot module build, no scons. Total CI surface
+matches the test trees in the standard above. Both check names
+should be added to `main`'s branch protection as required checks
+once the workflow has run at least once.
+
 **Follow-up candidates** for porting Godot-side state-machine logic
 into Godot-free slang_validate validators:
 

--- a/misc/install-slang.sh
+++ b/misc/install-slang.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Fetch the upstream Slang shader compiler for the godot-free
+# slang_validate test suite. Run from the repo root or pass the
+# install prefix explicitly.
+#
+# Usage:
+#   misc/install-slang.sh [install_prefix]
+#
+# Defaults to $SLANG_HOME or /tmp/slang. Prints the prefix on exit
+# so the caller can capture it (`SLANG_HOME=$(misc/install-slang.sh)`).
+# After install, the binary is at $prefix/bin/slangc.
+#
+# brew has no Slang shader formula (`s-lang` is John E. Davis's
+# S-Lang interpreter, unrelated). Upstream ships pre-built tarballs
+# on GitHub Releases. We pin against a known version so the
+# bit-exact slangc-cpp emits in tests/slang_validate stay stable.
+
+set -euo pipefail
+
+PREFIX="${1:-${SLANG_HOME:-/tmp/slang}}"
+SLANG_VERSION="${SLANG_VERSION:-2026.8.1}"
+
+case "$(uname -s)-$(uname -m)" in
+	Darwin-arm64)
+		ASSET="slang-${SLANG_VERSION}-macos-aarch64.zip"
+		EXT="zip"
+		;;
+	Darwin-x86_64)
+		ASSET="slang-${SLANG_VERSION}-macos-x86_64.zip"
+		EXT="zip"
+		;;
+	Linux-x86_64)
+		ASSET="slang-${SLANG_VERSION}-linux-x86_64.tar.gz"
+		EXT="tar.gz"
+		;;
+	Linux-aarch64)
+		ASSET="slang-${SLANG_VERSION}-linux-aarch64.tar.gz"
+		EXT="tar.gz"
+		;;
+	*)
+		echo "no prebuilt slang asset for $(uname -s)-$(uname -m)" >&2
+		echo "see https://github.com/shader-slang/slang/releases" >&2
+		exit 1
+		;;
+esac
+
+URL="https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/${ASSET}"
+
+echo "Installing Slang ${SLANG_VERSION} into ${PREFIX}" >&2
+echo "Fetching ${URL}" >&2
+mkdir -p "${PREFIX}"
+TMP="$(mktemp -d)"
+trap "rm -rf '${TMP}'" EXIT
+
+cd "${TMP}"
+curl -fL -o slang.archive "${URL}"
+case "${EXT}" in
+	zip)
+		unzip -q slang.archive
+		;;
+	tar.gz)
+		tar -xzf slang.archive
+		;;
+esac
+
+rm -rf "${PREFIX}"/{bin,lib,include,share,LICENSE,README.md} 2>/dev/null || true
+mv bin lib include share LICENSE README.md "${PREFIX}/"
+
+# Smoke-test the install.
+"${PREFIX}/bin/slangc" -v >&2
+
+echo "${PREFIX}"


### PR DESCRIPTION
## Summary

Closes gap #2 from the CI/CD audit: nothing on main was actually verifying that the Godot-free test trees build. This PR adds the missing workflow.

`static_checks.yml` already covers clang-format + file-format. The dormant `runner.yml` only fires on `convert-to-gdextension`. So a `#include` typo in `tests/slang_validate/`, a Lean kernel regression, or an audio model breakage would have slipped through.

## What lands

- **`.github/workflows/godot_free_ci.yml`** — new workflow, runs on every push + PR to main.
- **`misc/install-slang.sh`** — vendored from cloth_dynamics with a tweak to write to a caller-supplied prefix; pins slangc v2026.8.1 so the bit-exact emit fixtures stay stable.

## Workflow jobs

| Check name | Runner | What it does |
|---|---|---|
| `Slang validators (ubuntu-latest)` | ubuntu-latest | elan + Lean, slangc, `lake build Speech emit_shaders`, `make -C tests/slang_validate test-cpp` |
| `Slang validators (macos-latest)` | macos-latest | same + `make metal-discipline` (slangc-metal → xcrun metal → .metallib) |
| `Audio model (macOS, CoreAudio)` | macos-latest | `cmake --build tests/godot_audio_model && ./build/godot_audio_model_smoke` |

No `godot-cpp`, no Godot engine, no scons.

## Followup (after this PR merges)

Branch protection on `main` should add the three new check names to the required-checks list. I'll handle that as a follow-up `gh api PUT /repos/V-Sekai/godot-speech/branches/main/protection` once the workflow has run at least once on main.

## Test plan

- [x] Local: `bash misc/install-slang.sh /tmp/slang_smoke` — fetches slang 2026.8.1 (~50 MB), unpacks, smoke-tests the binary
- [x] Local: `make -C tests/slang_validate test` with the installed slangc — all seven validators green on cpp + metal
- [x] Local: `cmake --build tests/godot_audio_model/build && ./build/godot_audio_model_smoke` — driver name = CoreAudio, speaker mode = 0
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean