### PR TITLE
CI fix: include pcm_roundtrip_test in BINS at parse time

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -1,0 +1,87 @@
+name: 🧪 Godot-free CI
+
+# Build verification for the Godot-engine-independent test trees:
+#   * tests/slang_validate/  — Lean-formalized kernels + slangc-cpp + bit-exact CPU validators
+#   * tests/godot_audio_model/  — CMake-built stand-in for Godot's audio API, with the verbatim macOS CoreAudio driver
+#
+# Neither tree links against godot-cpp or the Godot engine; this
+# workflow exists precisely to keep them buildable on every PR
+# touching speech*, lean/, tests/slang_validate/, or
+# tests/godot_audio_model/.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  slang_validate:
+    name: Slang validators (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Lean 4 toolchain via elan. We pin in lean/lean-toolchain
+      # (currently leanprover/lean4:v4.29.1); elan reads it from cwd.
+      - name: Install elan + Lean
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Lake build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lean/.lake
+            ~/.elan/toolchains
+          key: lake-${{ matrix.os }}-${{ hashFiles('lean/lean-toolchain', 'lean/lake-manifest.json') }}
+
+      - name: Build Lean tree (native_decide pins)
+        working-directory: lean
+        run: lake build Speech emit_shaders
+
+      - name: Install slangc (pinned)
+        env:
+          SLANG_HOME: ${{ runner.temp }}/slang
+        run: |
+          bash misc/install-slang.sh "$SLANG_HOME"
+          echo "SLANG_HOME=$SLANG_HOME" >> "$GITHUB_ENV"
+          echo "$SLANG_HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Run slang validators (cpp target — bit-exact)
+        working-directory: tests/slang_validate
+        run: SLANGC="$SLANG_HOME/bin/slangc" make test-cpp
+
+      - name: Run slang validators (metal target — discipline)
+        if: runner.os == 'macOS'
+        working-directory: tests/slang_validate
+        run: SLANGC="$SLANG_HOME/bin/slangc" make metal-discipline
+
+  audio_model_macos:
+    name: Audio model (macOS, CoreAudio)
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure CMake
+        working-directory: tests/godot_audio_model
+        run: cmake -S . -B build -G "Unix Makefiles"
+
+      - name: Build
+        working-directory: tests/godot_audio_model
+        run: cmake --build build --parallel
+
+      - name: Smoke test
+        working-directory: tests/godot_audio_model
+        run: ./build/godot_audio_model_smoke

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -361,6 +361,25 @@ require the engine. The math layer should stay independent.
   divergence between it and a Godot-side test is a finding worth
   recording.
 
+**CI coverage:** the `.github/workflows/godot_free_ci.yml` workflow
+runs the Godot-free trees on every PR + main push:
+
+* `Slang validators (ubuntu-latest)` and `Slang validators (macos-latest)` —
+  install Lean via elan, install pinned `slangc` v2026.8.1 via
+  `misc/install-slang.sh`, build the Lean tree (`native_decide`
+  pins), then run `make -C tests/slang_validate test-cpp`. The
+  macOS job additionally runs `metal-discipline` (slangc-metal →
+  xcrun metal → .metallib) so the dual-target discipline check
+  doesn't rot.
+* `Audio model (macOS, CoreAudio)` — `cmake --build` the
+  `tests/godot_audio_model/` tree on macOS (including the verbatim
+  CoreAudio driver) and run the smoke test.
+
+No `godot-cpp`, no Godot module build, no scons. Total CI surface
+matches the test trees in the standard above. Both check names
+should be added to `main`'s branch protection as required checks
+once the workflow has run at least once.
+
 **Follow-up candidates** for porting Godot-side state-machine logic
 into Godot-free slang_validate validators:
 

--- a/misc/install-slang.sh
+++ b/misc/install-slang.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Fetch the upstream Slang shader compiler for the godot-free
+# slang_validate test suite. Run from the repo root or pass the
+# install prefix explicitly.
+#
+# Usage:
+#   misc/install-slang.sh [install_prefix]
+#
+# Defaults to $SLANG_HOME or /tmp/slang. Prints the prefix on exit
+# so the caller can capture it (`SLANG_HOME=$(misc/install-slang.sh)`).
+# After install, the binary is at $prefix/bin/slangc.
+#
+# brew has no Slang shader formula (`s-lang` is John E. Davis's
+# S-Lang interpreter, unrelated). Upstream ships pre-built tarballs
+# on GitHub Releases. We pin against a known version so the
+# bit-exact slangc-cpp emits in tests/slang_validate stay stable.
+
+set -euo pipefail
+
+PREFIX="${1:-${SLANG_HOME:-/tmp/slang}}"
+SLANG_VERSION="${SLANG_VERSION:-2026.8.1}"
+
+case "$(uname -s)-$(uname -m)" in
+	Darwin-arm64)
+		ASSET="slang-${SLANG_VERSION}-macos-aarch64.zip"
+		EXT="zip"
+		;;
+	Darwin-x86_64)
+		ASSET="slang-${SLANG_VERSION}-macos-x86_64.zip"
+		EXT="zip"
+		;;
+	Linux-x86_64)
+		ASSET="slang-${SLANG_VERSION}-linux-x86_64.tar.gz"
+		EXT="tar.gz"
+		;;
+	Linux-aarch64)
+		ASSET="slang-${SLANG_VERSION}-linux-aarch64.tar.gz"
+		EXT="tar.gz"
+		;;
+	*)
+		echo "no prebuilt slang asset for $(uname -s)-$(uname -m)" >&2
+		echo "see https://github.com/shader-slang/slang/releases" >&2
+		exit 1
+		;;
+esac
+
+URL="https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/${ASSET}"
+
+echo "Installing Slang ${SLANG_VERSION} into ${PREFIX}" >&2
+echo "Fetching ${URL}" >&2
+mkdir -p "${PREFIX}"
+TMP="$(mktemp -d)"
+trap "rm -rf '${TMP}'" EXIT
+
+cd "${TMP}"
+curl -fL -o slang.archive "${URL}"
+case "${EXT}" in
+	zip)
+		unzip -q slang.archive
+		;;
+	tar.gz)
+		tar -xzf slang.archive
+		;;
+esac
+
+rm -rf "${PREFIX}"/{bin,lib,include,share,LICENSE,README.md} 2>/dev/null || true
+mv bin lib include share LICENSE README.md "${PREFIX}/"
+
+# Smoke-test the install.
+"${PREFIX}/bin/slangc" -v >&2
+
+echo "${PREFIX}"

--- a/tests/slang_validate/Makefile
+++ b/tests/slang_validate/Makefile
@@ -56,7 +56,11 @@ KERNEL_FOR  = $(word 2,$(subst :, ,$(filter $(1):%,$(TESTS))))
 
 KERNELS    := $(sort $(foreach t,$(TESTS),$(word 2,$(subst :, ,$(t)))))
 SHADERS    := $(addprefix $(EMITTED)/,$(addsuffix _emit.cpp,$(KERNELS)))
-BINS       := $(addprefix $(EMITTED)/,$(addsuffix _test,$(TEST_NAMES)))
+# pcm_roundtrip_test is a multi-kernel composition (not in TESTS) but
+# must be included in BINS so `test-cpp` builds + runs it. Keep it
+# here so the dependency list is settled before `test-cpp: $(BINS)`.
+BINS       := $(addprefix $(EMITTED)/,$(addsuffix _test,$(TEST_NAMES))) \
+              $(EMITTED)/pcm_roundtrip_test
 
 .PHONY: test test-cpp test-metal clean emit-shaders metal-discipline
 
@@ -101,10 +105,6 @@ $(EMITTED)/pcm_roundtrip_test: pcm_roundtrip_test.cpp \
                                $(EMITTED)/pcm_to_s16_emit.cpp \
                                $(EMITTED)/pcm_from_s16_emit.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -I$(SLANG_INC) -o $@ $<
-
-# Add pcm_roundtrip to the test list (not in TESTS because it depends
-# on multiple kernels, but we still want `make test` to run it).
-BINS       += $(EMITTED)/pcm_roundtrip_test
 
 # ---- Metal discipline pipeline ----------------------------------------
 # slang -> .metal source -> .air -> .metallib. xcrun-only; skip on non-macOS.


### PR DESCRIPTION
## Summary

Fix the `Slang validators` job failure surfaced in PR #20's first run.

The Makefile had:

```make
test-cpp: $(BINS)           # ← prereq list captured here
   ...
BINS += $(EMITTED)/pcm_roundtrip_test    # ← appended later, never seen
```

GNU Make captures prerequisites at parse time when `:=` is used. The append happens too late; `make test-cpp` iterates `pcm_roundtrip_test` in its for-loop but make never builds it.

Locally the bug was masked because prior runs left the binary in `build/`. CI does a fresh checkout, so the binary genuinely didn't exist.

## Fix

Move `pcm_roundtrip_test` into the `BINS :=` definition directly so the dependency list is settled before any rule references it.

```make
BINS := $(addprefix $(EMITTED)/,$(addsuffix _test,$(TEST_NAMES))) \
        $(EMITTED)/pcm_roundtrip_test
```

## Test plan

- [x] `make clean test` locally — all seven validators green:
  ```
  frame_energy: 3/3 frames OK
  framing_cursor: 14 ticks OK + 5 bug-demo diffs
  jitter_append: 8/8 events OK
  pcm_from_s16: 9/9 samples OK
  pcm_to_s16: 9/9 samples OK
  vad_gate: 20/20 frames OK
  pcm_roundtrip: 65 sweep points OK; F3 gain pinned at 0.999969
  all kernels OK (cpp target)
  all kernels OK (metal target — discipline build)
  ```
- [x] Once this PR's CI is green, the `Slang validators (ubuntu-latest)`, `Slang validators (macos-latest)`, and `Audio model (macOS, CoreAudio)` checks can be added to `main`'s required-check list.