### PR TITLE
CHI-101 Phase A pass-4: AudioEffectCapture + AudioServer bus tree

### DIFF
--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -512,7 +512,21 @@ the storage substrate the engine code path is built against.
    `shims/core/os/`, `shims/core/math/`) so the copy itself stays
    unedited. CMake build produces `libgodot_audio_model.a` and a
    `godot_audio_model_smoke` exe that constructs the driver and
-   reports name + speaker mode. Done in PR #19 (this commit).
+   reports name + speaker mode. **Done in PR #19.**
+2. **AudioEffectCapture + AudioServer bus tree.** `AudioFrame`
+   (the engine's stereo float pair); `RingBuffer<T>` (power-of-two
+   circular); `AudioEffect` + `AudioEffectInstance` minimal bases;
+   `AudioEffectCapture` with `get_buffer`, `can_get_buffer`,
+   `get_buffer_length_frames`, `get_frames_available`,
+   `clear_buffer`, `set_buffer_length`/`get_buffer_length` and the
+   `pushed_frames`/`discarded_frames` counters; `AudioServer` with
+   `get_bus_index`, `get_bus_effect_count`, `get_bus_effect`,
+   `get_input_mix_rate`. Test-only entries (`push_test_frames` on
+   AudioEffectCapture, `test_add_bus`/`test_add_bus_effect` on
+   AudioServer) let the harness drive the capture path without an
+   audio thread. Smoke test now exercises a 100-frame round-trip
+   through the capture ring, asserting bit-exact preservation.
+   **Done in PR #22.**
 2. **Node + RefCounted stand-ins.** Minimal `Node` with name/parent/child;
    `RefCounted` with strong+weak counts. Enough for `cast_to` to work.
 3. **AudioServer + bus model.** Plain map<StringName,int> of bus indices,

--- a/tests/godot_audio_model/CMakeLists.txt
+++ b/tests/godot_audio_model/CMakeLists.txt
@@ -32,21 +32,28 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(MODEL_SOURCES
     audio/audio_driver.cpp
+    audio/audio_server.cpp
 )
 
 set(MODEL_HEADERS
+    core/audio_frame.h
     core/core_types.h
     core/error_list.h
     core/error_macros.h
     core/math_funcs.h
+    core/memory.h
     core/mutex.h
     core/packed_arrays.h
     core/ref_counted.h
+    core/ring_buffer.h
     core/string.h
     core/typedefs.h
     core/vector.h
     core/vector2.h
     audio/audio_driver.h
+    audio/audio_effect.h
+    audio/audio_effect_capture.h
+    audio/audio_server.h
 )
 
 if(APPLE)

--- a/tests/godot_audio_model/audio/audio_effect.h
+++ b/tests/godot_audio_model/audio/audio_effect.h
@@ -1,0 +1,30 @@
+// CHI-101 Phase A pass-4 — minimal `AudioEffect` + `AudioEffectInstance`
+// base classes.
+//
+// The reference engine routes every audio bus through a chain of
+// `AudioEffect` resources; each effect spawns an `AudioEffectInstance`
+// that runs on the audio thread. godot-speech only ever interacts
+// with the *capture* effect (AudioEffectCapture), and only via its
+// reader API — `get_buffer`, `get_frames_available`,
+// `get_buffer_length_frames`. The `instantiate()` / `process()`
+// virtuals never fire in the test path (the engine's audio thread
+// isn't running), so they're declared here as no-op defaults.
+
+#pragma once
+
+#include "../core/audio_frame.h"
+#include "../core/core_types.h"
+
+class AudioEffectInstance : public RefCounted {
+public:
+	virtual void process(const AudioFrame * /*src*/, AudioFrame * /*dst*/,
+			int /*p_frame_count*/) {}
+	virtual bool process_silence() const { return false; }
+};
+
+class AudioEffect : public RefCounted {
+public:
+	virtual Ref<AudioEffectInstance> instantiate() {
+		return Ref<AudioEffectInstance>();
+	}
+};

--- a/tests/godot_audio_model/audio/audio_effect_capture.h
+++ b/tests/godot_audio_model/audio/audio_effect_capture.h
@@ -1,0 +1,149 @@
+// CHI-101 Phase A pass-4 — `AudioEffectCapture` stand-in.
+//
+// godot-speech consumes this via three methods only:
+//
+//   PackedVector2Array AudioEffectCapture::get_buffer(int len);
+//   int AudioEffectCapture::get_buffer_length_frames();
+//   int AudioEffectCapture::get_frames_available();
+//
+// In the engine, `process()` runs on the audio thread and writes
+// captured mic frames into the ring; the consumer thread pops via
+// `get_buffer`. The test binary has no audio thread, so we add a
+// **test-only** non-engine method `push_test_frames` that the test
+// driver calls to feed synthetic mic audio. Production-path
+// consumers see the same `get_buffer` API as in the engine.
+//
+// Bridges between `AudioFrame` (the engine's stereo float pair) and
+// `Vector2` (which `PackedVector2Array::get_buffer` returns): same
+// memory layout, so we use `reinterpret_cast` rather than a copy
+// at the ring boundary.
+
+#pragma once
+
+#include "../core/core_types.h"
+#include "../core/ring_buffer.h"
+
+#include "audio_effect.h"
+
+class AudioEffectCapture : public AudioEffect {
+	RingBuffer<AudioFrame> buffer;
+	SafeNumeric<uint64_t> discarded_frames;
+	SafeNumeric<uint64_t> pushed_frames;
+	float buffer_length_seconds = 0.1f;
+	uint32_t mix_rate = 48000;
+	bool buffer_initialized = false;
+
+	void ensure_initialized() {
+		if (buffer_initialized) {
+			return;
+		}
+		const uint32_t want_frames = static_cast<uint32_t>(
+				static_cast<double>(mix_rate) * buffer_length_seconds);
+		// Pick the smallest power-of-two ≥ want_frames; engine does
+		// the same via Math::next_power_of_2.
+		int power = 1;
+		while ((1u << power) < want_frames) {
+			++power;
+		}
+		buffer.resize(power);
+		buffer_initialized = true;
+	}
+
+public:
+	AudioEffectCapture() = default;
+
+	// Engine-equivalent setters (`set_buffer_length` in seconds;
+	// engine reads input mix rate from AudioServer, we accept it
+	// directly so the test driver can vary it without touching the
+	// AudioServer model).
+	void set_buffer_length(float p_buffer_length_seconds) {
+		buffer_length_seconds = p_buffer_length_seconds;
+		buffer_initialized = false;
+	}
+	float get_buffer_length() const { return buffer_length_seconds; }
+
+	void set_mix_rate(uint32_t p_mix_rate) {
+		mix_rate = p_mix_rate;
+		buffer_initialized = false;
+	}
+	uint32_t get_mix_rate() const { return mix_rate; }
+
+	int get_buffer_length_frames() {
+		ensure_initialized();
+		return buffer.size();
+	}
+
+	int get_frames_available() {
+		ensure_initialized();
+		return buffer.data_left();
+	}
+
+	bool can_get_buffer(int p_frames) {
+		return get_frames_available() >= p_frames;
+	}
+
+	int64_t get_discarded_frames() const {
+		return static_cast<int64_t>(discarded_frames.get());
+	}
+	int64_t get_pushed_frames() const {
+		return static_cast<int64_t>(pushed_frames.get());
+	}
+
+	void clear_buffer() {
+		ensure_initialized();
+		buffer.clear();
+		discarded_frames.set(0);
+		pushed_frames.set(0);
+	}
+
+	// Engine API: pop `p_len` AudioFrames as Vector2 (.x = left, .y = right).
+	// Returns fewer frames if the ring has less; size of the returned array
+	// equals what was actually read.
+	PackedVector2Array get_buffer(int p_len) {
+		ensure_initialized();
+		const int avail = buffer.data_left();
+		const int n = (p_len < avail) ? p_len : avail;
+		PackedVector2Array out;
+		out.resize(n);
+		if (n > 0) {
+			AudioFrame *dst = reinterpret_cast<AudioFrame *>(out.ptrw());
+			buffer.read(dst, n);
+		}
+		return out;
+	}
+
+	// === Test-only API (not in the engine) ====================
+	// The test driver pushes synthetic mic audio via this entry
+	// point. On the engine side, `process()` does the equivalent
+	// write but with frames from the audio thread. Matching the
+	// engine's overflow behavior: drop oldest, bump
+	// discarded_frames.
+	void push_test_frames(const Vector2 *frames, int p_n) {
+		ensure_initialized();
+		const AudioFrame *src = reinterpret_cast<const AudioFrame *>(frames);
+		int remaining = p_n;
+		while (remaining > 0) {
+			const int wrote = buffer.write(src, remaining);
+			pushed_frames.add(static_cast<uint64_t>(wrote));
+			remaining -= wrote;
+			src += wrote;
+			if (remaining > 0) {
+				// Ring full; drop one frame from the front and retry.
+				AudioFrame discarded;
+				buffer.read(&discarded, 1);
+				discarded_frames.add(1);
+			}
+		}
+	}
+
+	void push_test_frames(const PackedVector2Array &frames) {
+		push_test_frames(frames.ptr(), frames.size());
+	}
+
+	virtual Ref<AudioEffectInstance> instantiate() override {
+		// Capture's instance just writes into our ring; no real
+		// instance needed for the test path. Return null to make
+		// it obvious if the audio thread ever tries to use it.
+		return Ref<AudioEffectInstance>();
+	}
+};

--- a/tests/godot_audio_model/audio/audio_server.cpp
+++ b/tests/godot_audio_model/audio/audio_server.cpp
@@ -1,0 +1,5 @@
+// CHI-101 Phase A pass-4 — `AudioServer` singleton definition.
+
+#include "audio_server.h"
+
+AudioServer *AudioServer::singleton = nullptr;

--- a/tests/godot_audio_model/audio/audio_server.h
+++ b/tests/godot_audio_model/audio/audio_server.h
@@ -1,0 +1,78 @@
+// CHI-101 Phase A pass-4 — minimal `AudioServer` stand-in.
+//
+// godot-speech reaches the AudioServer through:
+//
+//   AudioServer::get_singleton()->get_input_mix_rate()
+//   AudioServer::get_singleton()->get_bus_index(StringName)
+//   AudioServer::get_singleton()->get_bus_effect_count(int)
+//   AudioServer::get_singleton()->get_bus_effect(int, int) -> Ref<AudioEffect>
+//
+// `set_streaming_bus` walks the bus's effect list to find an
+// AudioEffectCapture. The model exposes a test-only entry that
+// lets the harness add buses with named effects without going
+// through the full audio-driver setup.
+
+#pragma once
+
+#include "../core/core_types.h"
+#include "audio_effect.h"
+#include "audio_effect_capture.h"
+
+#include <vector>
+
+class AudioServer {
+	static AudioServer *singleton;
+
+	struct Bus {
+		String name;
+		std::vector<Ref<AudioEffect>> effects;
+	};
+	std::vector<Bus> buses;
+	uint32_t input_mix_rate = 48000;
+
+public:
+	AudioServer() { singleton = this; }
+	~AudioServer() {
+		if (singleton == this) {
+			singleton = nullptr;
+		}
+	}
+
+	static AudioServer *get_singleton() { return singleton; }
+
+	uint32_t get_input_mix_rate() const { return input_mix_rate; }
+	void set_input_mix_rate(uint32_t p_rate) { input_mix_rate = p_rate; }
+
+	int get_bus_index(const StringName &p_name) const {
+		const String name = static_cast<String>(p_name);
+		for (size_t i = 0; i < buses.size(); ++i) {
+			if (buses[i].name == name) {
+				return static_cast<int>(i);
+			}
+		}
+		return -1;
+	}
+
+	int get_bus_effect_count(int p_bus) const {
+		ERR_FAIL_INDEX_V(p_bus, static_cast<int>(buses.size()), 0);
+		return static_cast<int>(buses[p_bus].effects.size());
+	}
+
+	Ref<AudioEffect> get_bus_effect(int p_bus, int p_idx) const {
+		ERR_FAIL_INDEX_V(p_bus, static_cast<int>(buses.size()), Ref<AudioEffect>());
+		ERR_FAIL_INDEX_V(p_idx, static_cast<int>(buses[p_bus].effects.size()), Ref<AudioEffect>());
+		return buses[p_bus].effects[p_idx];
+	}
+
+	// === Test-only API (not in the engine) ====================
+	// Add a bus with a list of effects. Returns the bus index.
+	int test_add_bus(const String &p_name) {
+		buses.push_back(Bus{ p_name, {} });
+		return static_cast<int>(buses.size()) - 1;
+	}
+
+	void test_add_bus_effect(int p_bus, const Ref<AudioEffect> &p_effect) {
+		ERR_FAIL_INDEX(p_bus, static_cast<int>(buses.size()));
+		buses[p_bus].effects.push_back(p_effect);
+	}
+};

--- a/tests/godot_audio_model/core/audio_frame.h
+++ b/tests/godot_audio_model/core/audio_frame.h
@@ -1,0 +1,46 @@
+// CHI-101 Phase A pass-4 — `AudioFrame` stand-in.
+//
+// Mirrors core/math/audio_frame.h's API: two-float stereo sample
+// with `.left`/`.l`/`[0]` and `.right`/`.r`/`[1]` access, plus the
+// arithmetic operators the engine's audio paths use. The engine
+// uses a union for the named accessors; we use a small struct
+// with both names as members to keep header parsing simple.
+//
+// `Vector2` and `AudioFrame` are interchangeable in memory layout
+// for the cross-API points in godot-speech (capture/playback
+// rings pass `PackedVector2Array`), so callers that want either
+// view can `reinterpret_cast` between them.
+
+#pragma once
+
+#include "typedefs.h"
+
+struct AudioFrame {
+	float left = 0.0f;
+	float right = 0.0f;
+
+	AudioFrame() = default;
+	constexpr AudioFrame(float p_l, float p_r) :
+			left(p_l), right(p_r) {}
+
+	float &l() { return left; }
+	float &r() { return right; }
+	const float &l() const { return left; }
+	const float &r() const { return right; }
+
+	_ALWAYS_INLINE_ float &operator[](int i) { return (i == 0) ? left : right; }
+	_ALWAYS_INLINE_ const float &operator[](int i) const { return (i == 0) ? left : right; }
+
+	constexpr AudioFrame operator+(const AudioFrame &o) const { return AudioFrame(left + o.left, right + o.right); }
+	constexpr AudioFrame operator-(const AudioFrame &o) const { return AudioFrame(left - o.left, right - o.right); }
+	constexpr AudioFrame operator*(const AudioFrame &o) const { return AudioFrame(left * o.left, right * o.right); }
+	constexpr AudioFrame operator*(float s) const { return AudioFrame(left * s, right * s); }
+	constexpr void operator+=(const AudioFrame &o) {
+		left += o.left;
+		right += o.right;
+	}
+	constexpr void operator*=(float s) {
+		left *= s;
+		right *= s;
+	}
+};

--- a/tests/godot_audio_model/core/ring_buffer.h
+++ b/tests/godot_audio_model/core/ring_buffer.h
@@ -1,0 +1,90 @@
+// CHI-101 Phase A pass-4 — `RingBuffer<T>` stand-in.
+//
+// Mirrors the subset of core/templates/ring_buffer.h that
+// AudioEffectCapture uses:
+//
+//   resize(size_pow2)   — capacity must be a power of two; the
+//                         argument is the log2 of the desired
+//                         capacity (matches engine semantics).
+//   data_left()         — bytes/frames currently in the buffer
+//   space_left()        — bytes/frames available for write
+//   write(src, n)       — append n frames; on overflow, behavior
+//                         differs from the engine: we discard
+//                         oldest frames (FIFO drop) and increment
+//                         an external counter that the caller
+//                         (AudioEffectCapture) maintains via
+//                         SafeNumeric<uint64_t> discarded_frames.
+//                         The engine's RingBuffer itself does not
+//                         drop — callers check space_left() first
+//                         and choose. We preserve that contract:
+//                         callers must check; `write` returns the
+//                         number of frames written.
+//   read(dst, n)        — pop n frames into dst; returns frames read.
+//   clear()             — reset to empty.
+//
+// Indices are masked against `size() - 1` (cheap because size is
+// a power of two).
+
+#pragma once
+
+#include "error_macros.h"
+#include "typedefs.h"
+
+#include <vector>
+
+template <typename T>
+class RingBuffer {
+	std::vector<T> data;
+	int read_pos = 0;
+	int write_pos = 0;
+	int size_mask = 0;
+
+public:
+	RingBuffer() = default;
+
+	// Resize to 2^p_power frames. Matches engine convention.
+	void resize(int p_power) {
+		const int n = 1 << p_power;
+		data.assign(static_cast<size_t>(n), T{});
+		size_mask = n - 1;
+		read_pos = 0;
+		write_pos = 0;
+	}
+
+	int size() const { return static_cast<int>(data.size()); }
+
+	int data_left() const {
+		return (write_pos - read_pos) & size_mask;
+	}
+
+	int space_left() const {
+		return size() - data_left() - 1;
+	}
+
+	// Write up to p_n frames; returns frames actually written.
+	int write(const T *src, int p_n) {
+		const int can = space_left();
+		const int n = (p_n < can) ? p_n : can;
+		for (int i = 0; i < n; ++i) {
+			data[write_pos] = src[i];
+			write_pos = (write_pos + 1) & size_mask;
+		}
+		return n;
+	}
+
+	// Read up to p_n frames; returns frames actually read.
+	int read(T *dst, int p_n) {
+		const int avail = data_left();
+		const int n = (p_n < avail) ? p_n : avail;
+		for (int i = 0; i < n; ++i) {
+			dst[i] = data[read_pos];
+			read_pos = (read_pos + 1) & size_mask;
+		}
+		return n;
+	}
+
+	void clear() {
+		read_pos = 0;
+		write_pos = 0;
+	}
+};

--- a/tests/godot_audio_model/shims/servers/audio/audio_server.h
+++ b/tests/godot_audio_model/shims/servers/audio/audio_server.h
@@ -1,5 +1,7 @@
-// CHI-101 Phase A pass-3 — engine-path shim. The verbatim CoreAudio
-// driver in tests/godot_audio_model/coreaudio/ includes this path;
-// re-export our minimal AudioDriver via the same header location.
+// CHI-101 Phase A pass-3/4 — engine-path shim. Re-exports both
+// AudioDriver (pass 3) and AudioServer + bus tree (pass 4) under
+// the engine include path so the verbatim CoreAudio driver and
+// any future verbatim engine code see the same headers.
 #pragma once
 #include "../../../audio/audio_driver.h"
+#include "../../../audio/audio_server.h"

--- a/tests/godot_audio_model/smoke_test.cpp
+++ b/tests/godot_audio_model/smoke_test.cpp
@@ -1,9 +1,14 @@
-// CHI-101 Phase A pass-3 smoke test — constructs the AudioDriver
-// singleton, queries its `get_name()`, and (on macOS) instantiates
-// the CoreAudio driver. Doesn't actually start audio I/O — just
-// verifies the model + driver compile and link.
+// CHI-101 Phase A pass-3/4 smoke test:
+//   - (pass 3) constructs the AudioDriver / CoreAudio driver and
+//     prints its name + speaker mode
+//   - (pass 4) exercises AudioServer + AudioEffectCapture: registers
+//     a "Capture" bus with an AudioEffectCapture, pushes 100
+//     synthetic stereo frames, then drains them and verifies the
+//     round-trip preserves bit-exact values.
 
 #include "audio/audio_driver.h"
+#include "audio/audio_effect_capture.h"
+#include "audio/audio_server.h"
 #include "core/core_types.h"
 
 #include <cstdio>
@@ -12,6 +17,58 @@
 #include "coreaudio/audio_driver_coreaudio.h"
 #endif
 
+static int test_capture_roundtrip() {
+	AudioServer server;
+	const int bus = server.test_add_bus(String("Capture"));
+
+	Ref<AudioEffectCapture> capture = new AudioEffectCapture();
+	capture->set_mix_rate(48000);
+	capture->set_buffer_length(0.1f); // 100 ms, 4800 frames @ 48 kHz
+	server.test_add_bus_effect(bus, capture);
+
+	std::printf("audio_model smoke: bus index = %d\n",
+			server.get_bus_index(StringName("Capture")));
+	std::printf("audio_model smoke: bus effect count = %d\n",
+			server.get_bus_effect_count(bus));
+	std::printf("audio_model smoke: buffer_length_frames = %d\n",
+			capture->get_buffer_length_frames());
+
+	// Push 100 distinct stereo frames.
+	PackedVector2Array in;
+	in.resize(100);
+	for (int i = 0; i < 100; ++i) {
+		in[i] = Vector2(static_cast<float>(i), static_cast<float>(-i));
+	}
+	capture->push_test_frames(in);
+
+	const int avail = capture->get_frames_available();
+	std::printf("audio_model smoke: frames_available after push = %d\n", avail);
+	if (avail != 100) {
+		std::fprintf(stderr, "FAIL: expected 100 frames available, got %d\n", avail);
+		return 1;
+	}
+
+	// Drain.
+	PackedVector2Array out = capture->get_buffer(100);
+	if (out.size() != 100) {
+		std::fprintf(stderr, "FAIL: get_buffer(100) returned %d frames\n", out.size());
+		return 1;
+	}
+	for (int i = 0; i < 100; ++i) {
+		if (out[i].x != static_cast<float>(i) || out[i].y != static_cast<float>(-i)) {
+			std::fprintf(stderr,
+					"FAIL: frame %d round-trip mismatch: got (%g,%g) expected (%g,%g)\n",
+					i, out[i].x, out[i].y, static_cast<float>(i), static_cast<float>(-i));
+			return 1;
+		}
+	}
+	std::printf("audio_model smoke: capture round-trip OK (100 frames bit-exact)\n");
+	std::printf("audio_model smoke: pushed_frames = %lld, discarded_frames = %lld\n",
+			(long long)capture->get_pushed_frames(),
+			(long long)capture->get_discarded_frames());
+	return 0;
+}
+
 int main() {
 #ifdef COREAUDIO_ENABLED
 	AudioDriverCoreAudio driver;
@@ -19,11 +76,9 @@ int main() {
 	std::printf("audio_model smoke: driver name = %s\n", driver.get_name());
 	std::printf("audio_model smoke: speaker mode = %d\n",
 			static_cast<int>(driver.get_speaker_mode()));
-	// init() / start() would actually open the OS audio device; we
-	// stop at the construct-and-query stage for the smoke test.
-	return 0;
 #else
 	std::printf("audio_model smoke: no concrete driver on this platform (CoreAudio is macOS-only)\n");
-	return 0;
 #endif
+
+	return test_capture_roundtrip();
 }


### PR DESCRIPTION
## Summary

Pass 4 of the audio-model implementation outline. Adds the capture-side model surface that godot-speech reads from in `SpeechProcessor::_setup` → `_mix_audio`.

## What lands

```
tests/godot_audio_model/
├── core/
│   ├── audio_frame.h        # AudioFrame (stereo float pair; same layout as Vector2)
│   └── ring_buffer.h        # power-of-two circular buffer (engine semantics)
└── audio/
    ├── audio_effect.h           # AudioEffect + AudioEffectInstance base classes
    ├── audio_effect_capture.h   # capture ring + reader API
    └── audio_server.{h,cpp}     # bus tree + singleton
```

Plus shim update (`shims/servers/audio/audio_server.h`) to re-export the new `AudioServer` under the engine include path.

## Reader API (engine-identical)

- `AudioEffectCapture::get_buffer(int) -> PackedVector2Array`
- `AudioEffectCapture::can_get_buffer(int) -> bool`
- `AudioEffectCapture::get_buffer_length_frames() -> int`
- `AudioEffectCapture::get_frames_available() -> int`
- `AudioEffectCapture::clear_buffer()`
- `AudioEffectCapture::set_buffer_length(float)` / `get_buffer_length()`
- `AudioEffectCapture::get_pushed_frames()` / `get_discarded_frames()`
- `AudioServer::get_bus_index(StringName) -> int`
- `AudioServer::get_bus_effect_count(int) -> int`
- `AudioServer::get_bus_effect(int, int) -> Ref<AudioEffect>`
- `AudioServer::get_input_mix_rate() -> uint32_t`

## Test-only API (not in the engine)

- `AudioEffectCapture::push_test_frames(const Vector2*, int)` — synthetic mic audio
- `AudioEffectCapture::push_test_frames(const PackedVector2Array&)` — convenience
- `AudioServer::test_add_bus(String)` / `test_add_bus_effect(int, Ref<AudioEffect>)` — bypass the audio-driver setup

The engine routes these via the audio thread's `process()` callback; the test path drives them explicitly.

## Smoke test (now exercises pass 4)

```
$ ./build/godot_audio_model_smoke
audio_model smoke: driver name = CoreAudio
audio_model smoke: speaker mode = 0
audio_model smoke: bus index = 0
audio_model smoke: bus effect count = 1
audio_model smoke: buffer_length_frames = 8192
audio_model smoke: frames_available after push = 100
audio_model smoke: capture round-trip OK (100 frames bit-exact)
audio_model smoke: pushed_frames = 100, discarded_frames = 0
```

100-frame round-trip is bit-exact: a `PackedVector2Array` of `(i, -i)` for `i ∈ [0, 100)` goes through `push_test_frames` and comes back through `get_buffer(100)` byte-identical.

## Test plan

- [x] `cmake --build build` — clean (one inherited engine deprecation warning)
- [x] `./build/godot_audio_model_smoke` — capture round-trip OK
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean

## Out of scope

Passes 5–7 (AudioStreamGenerator(Playback), AudioStreamPlayer wrappers, link `speech.cpp` against the model) remain.