### PR TITLE
CHI-101 Phase A pass-5: AudioStreamGenerator + AudioStreamGeneratorPlayback

### DIFF
--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -527,6 +527,21 @@ the storage substrate the engine code path is built against.
    audio thread. Smoke test now exercises a 100-frame round-trip
    through the capture ring, asserting bit-exact preservation.
    **Done in PR #22.**
+3. **AudioStreamGenerator + AudioStreamGeneratorPlayback.** Playback
+   side of the audio model. `AudioStream` and `AudioStreamPlayback`
+   intermediate base classes (engine has a deeper hierarchy via
+   `AudioStreamPlaybackResampled`; we flatten since godot-speech
+   only calls the leaf API). `AudioStreamGenerator` with
+   `set_mix_rate`/`get_mix_rate`, `set_buffer_length`/`get_buffer_length`,
+   and `instantiate_playback()` factory. `AudioStreamGeneratorPlayback`
+   with `push_buffer(PackedVector2Array) -> bool`, `can_push_buffer`,
+   `get_frames_available()` (engine semantics: FREE write room, not
+   data in buffer), and `get_skips()` overflow counter. Test-only
+   `consume_test_frames(int)` / `consume_test_frames_into(int)`
+   simulates the speaker drain that the engine's audio thread would
+   otherwise do. Smoke test pushes 480 frames, drains them with
+   bit-exact verification, then forces an overflow to confirm skips
+   increments. **Done in PR #23.**
 2. **Node + RefCounted stand-ins.** Minimal `Node` with name/parent/child;
    `RefCounted` with strong+weak counts. Enough for `cast_to` to work.
 3. **AudioServer + bus model.** Plain map<StringName,int> of bus indices,

--- a/tests/godot_audio_model/CMakeLists.txt
+++ b/tests/godot_audio_model/CMakeLists.txt
@@ -54,6 +54,8 @@ set(MODEL_HEADERS
     audio/audio_effect.h
     audio/audio_effect_capture.h
     audio/audio_server.h
+    audio/audio_stream.h
+    audio/audio_stream_generator.h
 )
 
 if(APPLE)

--- a/tests/godot_audio_model/audio/audio_stream.h
+++ b/tests/godot_audio_model/audio/audio_stream.h
@@ -1,0 +1,28 @@
+// CHI-101 Phase A pass-5 — minimal `AudioStream` + `AudioStreamPlayback`
+// base classes for the playback side.
+//
+// The reference engine has a deeper hierarchy:
+//
+//   Resource → AudioStream → AudioStreamGenerator
+//   RefCounted → AudioStreamPlayback
+//              → AudioStreamPlaybackResampled
+//              → AudioStreamGeneratorPlayback
+//
+// We flatten that for the test binary — `AudioStream` and
+// `AudioStreamPlayback` are both direct RefCounted descendants here,
+// and the Playback intermediate layer is skipped since godot-speech
+// only calls the leaf `AudioStreamGeneratorPlayback`'s API.
+
+#pragma once
+
+#include "../core/core_types.h"
+
+class AudioStream : public RefCounted {
+public:
+	virtual ~AudioStream() = default;
+};
+
+class AudioStreamPlayback : public RefCounted {
+public:
+	virtual ~AudioStreamPlayback() = default;
+};

--- a/tests/godot_audio_model/audio/audio_stream_generator.h
+++ b/tests/godot_audio_model/audio/audio_stream_generator.h
@@ -1,0 +1,133 @@
+// CHI-101 Phase A pass-5 — `AudioStreamGenerator` +
+// `AudioStreamGeneratorPlayback` stand-ins.
+//
+// godot-speech uses this as the speaker-side ring on the receive
+// path: every incoming voice packet decoded by
+// `Speech::attempt_to_feed_stream` is `push_buffer`-ed into the
+// playback; the engine's audio thread normally drains the ring at
+// `mix_rate`. The test binary has no audio thread, so a test-only
+// `consume_test_frames(int)` simulates the speaker draining.
+//
+// Engine reader-API godot-speech depends on:
+//
+//   AudioStreamGenerator::set_mix_rate(float) / get_mix_rate() -> float
+//   AudioStreamGenerator::set_buffer_length(float) / get_buffer_length() -> float
+//   AudioStreamGeneratorPlayback::push_buffer(PackedVector2Array) -> bool
+//   AudioStreamGeneratorPlayback::get_frames_available() -> int   (FREE space)
+//   AudioStreamGeneratorPlayback::get_skips() -> int              (overflow count)
+//
+// Note on get_frames_available semantics: the engine returns
+// available *write* room (frames that can still be pushed before
+// the ring overflows), NOT data-currently-in-buffer. godot-speech
+// uses it as `to_fill` in attempt_to_feed_stream, computing
+// `required_packets = floor(to_fill / 480)`. Matching that
+// convention is required for the runtime to agree with the
+// JitterAppend/FramingCursor kernels' expectations.
+
+#pragma once
+
+#include "../core/audio_frame.h"
+#include "../core/core_types.h"
+#include "../core/ring_buffer.h"
+#include "audio_stream.h"
+
+class AudioStreamGenerator;
+
+class AudioStreamGeneratorPlayback : public AudioStreamPlayback {
+	friend class AudioStreamGenerator;
+
+	RingBuffer<AudioFrame> buffer;
+	SafeNumeric<int> skips;
+	int total_capacity = 0;
+	bool buffer_initialized = false;
+
+	void initialize(float mix_rate, float buffer_length_seconds) {
+		const int want_frames = static_cast<int>(mix_rate * buffer_length_seconds);
+		int power = 1;
+		while ((1 << power) < want_frames) {
+			++power;
+		}
+		buffer.resize(power);
+		total_capacity = buffer.size();
+		buffer_initialized = true;
+	}
+
+public:
+	int get_frames_available() const {
+		// Engine convention: free *write* room.
+		return buffer.space_left();
+	}
+
+	int get_skips() const { return skips.get(); }
+
+	bool push_buffer(const PackedVector2Array &frames) {
+		const int n = frames.size();
+		if (n == 0) {
+			return true;
+		}
+		if (buffer.space_left() < n) {
+			skips.increment();
+			return false;
+		}
+		const AudioFrame *src = reinterpret_cast<const AudioFrame *>(frames.ptr());
+		const int wrote = buffer.write(src, n);
+		return wrote == n;
+	}
+
+	// Engine has `can_push_buffer(int)` on the playback in some
+	// branches; mirror it for completeness.
+	bool can_push_buffer(int frames) const {
+		return buffer.space_left() >= frames;
+	}
+
+	int get_total_capacity() const { return total_capacity; }
+
+	// === Test-only API ========================================
+	// Simulates the speaker draining N frames. Returns frames
+	// actually consumed (less than N if the ring runs dry — the
+	// engine's audio thread would silence-fill in this case).
+	int consume_test_frames(int n) {
+		AudioFrame discard[256];
+		int consumed = 0;
+		while (consumed < n) {
+			const int chunk = ((n - consumed) < 256) ? (n - consumed) : 256;
+			const int got = buffer.read(discard, chunk);
+			if (got == 0) {
+				break;
+			}
+			consumed += got;
+		}
+		return consumed;
+	}
+
+	// Drain into a caller-supplied output for inspection.
+	PackedVector2Array consume_test_frames_into(int n) {
+		PackedVector2Array out;
+		out.resize(n);
+		AudioFrame *dst = reinterpret_cast<AudioFrame *>(out.ptrw());
+		const int got = buffer.read(dst, n);
+		out.resize(got);
+		return out;
+	}
+};
+
+class AudioStreamGenerator : public AudioStream {
+	float mix_rate = 44100.0f;
+	float buffer_length_seconds = 0.5f;
+
+public:
+	void set_mix_rate(float p_rate) { mix_rate = p_rate; }
+	float get_mix_rate() const { return mix_rate; }
+
+	void set_buffer_length(float p_seconds) {
+		buffer_length_seconds = p_seconds;
+	}
+	float get_buffer_length() const { return buffer_length_seconds; }
+
+	// Engine API: `instantiate_playback()` constructs the playback.
+	Ref<AudioStreamGeneratorPlayback> instantiate_playback() {
+		Ref<AudioStreamGeneratorPlayback> pb = new AudioStreamGeneratorPlayback();
+		pb->initialize(mix_rate, buffer_length_seconds);
+		return pb;
+	}
+};

--- a/tests/godot_audio_model/smoke_test.cpp
+++ b/tests/godot_audio_model/smoke_test.cpp
@@ -9,6 +9,7 @@
 #include "audio/audio_driver.h"
 #include "audio/audio_effect_capture.h"
 #include "audio/audio_server.h"
+#include "audio/audio_stream_generator.h"
 #include "core/core_types.h"
 
 #include <cstdio>
@@ -69,6 +70,80 @@ static int test_capture_roundtrip() {
 	return 0;
 }
 
+static int test_playback_roundtrip() {
+	// Allocate a 100 ms playback ring at 48 kHz.
+	Ref<AudioStreamGenerator> gen = new AudioStreamGenerator();
+	gen->set_mix_rate(48000.0f);
+	gen->set_buffer_length(0.1f);
+	Ref<AudioStreamGeneratorPlayback> playback = gen->instantiate_playback();
+
+	const int cap = playback->get_total_capacity();
+	std::printf("audio_model smoke: playback capacity = %d frames (%.1f ms)\n",
+			cap, 1000.0f * cap / 48000.0f);
+
+	const int initial_room = playback->get_frames_available();
+	if (initial_room != cap - 1) {
+		std::fprintf(stderr,
+				"FAIL: expected free room = %d, got %d (ring keeps 1 sentinel slot)\n",
+				cap - 1, initial_room);
+		return 1;
+	}
+
+	// Push 480 frames (one 10ms voice packet at 48kHz). All distinct
+	// so we can verify byte-for-byte preservation after draining.
+	PackedVector2Array pkt;
+	pkt.resize(480);
+	for (int i = 0; i < 480; ++i) {
+		pkt[i] = Vector2(static_cast<float>(i) * 0.001f, static_cast<float>(-i) * 0.001f);
+	}
+	if (!playback->push_buffer(pkt)) {
+		std::fprintf(stderr, "FAIL: push_buffer rejected a 480-frame packet into an empty ring\n");
+		return 1;
+	}
+	std::printf("audio_model smoke: after push 480: frames_available = %d, skips = %d\n",
+			playback->get_frames_available(), playback->get_skips());
+
+	// Drain 480 frames and confirm bit-exact preservation.
+	PackedVector2Array drained = playback->consume_test_frames_into(480);
+	if (drained.size() != 480) {
+		std::fprintf(stderr, "FAIL: drained %d frames, expected 480\n", drained.size());
+		return 1;
+	}
+	for (int i = 0; i < 480; ++i) {
+		const float ex = static_cast<float>(i) * 0.001f;
+		const float ey = static_cast<float>(-i) * 0.001f;
+		if (drained[i].x != ex || drained[i].y != ey) {
+			std::fprintf(stderr, "FAIL: drained[%d] = (%g, %g), expected (%g, %g)\n",
+					i, drained[i].x, drained[i].y, ex, ey);
+			return 1;
+		}
+	}
+
+	// Now overflow: try to push more than the ring holds, verify
+	// push_buffer returns false and skips increments.
+	PackedVector2Array oversize;
+	oversize.resize(cap + 100);
+	for (int i = 0; i < cap + 100; ++i) {
+		oversize[i] = Vector2(1.0f, 1.0f);
+	}
+	const int skips_before = playback->get_skips();
+	const bool ok = playback->push_buffer(oversize);
+	const int skips_after = playback->get_skips();
+	if (ok) {
+		std::fprintf(stderr, "FAIL: oversize push_buffer returned true\n");
+		return 1;
+	}
+	if (skips_after != skips_before + 1) {
+		std::fprintf(stderr,
+				"FAIL: skips counter %d -> %d after overflow (expected +1)\n",
+				skips_before, skips_after);
+		return 1;
+	}
+
+	std::printf("audio_model smoke: playback round-trip OK (480 frames bit-exact + overflow skip detected)\n");
+	return 0;
+}
+
 int main() {
 #ifdef COREAUDIO_ENABLED
 	AudioDriverCoreAudio driver;
@@ -80,5 +155,8 @@ int main() {
 	std::printf("audio_model smoke: no concrete driver on this platform (CoreAudio is macOS-only)\n");
 #endif
 
-	return test_capture_roundtrip();
+	if (int rc = test_capture_roundtrip()) {
+		return rc;
+	}
+	return test_playback_roundtrip();
 }


### PR DESCRIPTION
## Summary

Pass 5 of the audio-model implementation outline — the playback-side surface that godot-speech writes to in `Speech::attempt_to_feed_stream`.

## What lands

```
tests/godot_audio_model/audio/
├── audio_stream.h              # AudioStream + AudioStreamPlayback bases (RefCounted)
└── audio_stream_generator.h    # AudioStreamGenerator + AudioStreamGeneratorPlayback
```

Engine reader API (verbatim signatures):
- `AudioStreamGenerator::set_mix_rate(float)` / `get_mix_rate()`
- `AudioStreamGenerator::set_buffer_length(float)` / `get_buffer_length()`
- `AudioStreamGenerator::instantiate_playback() -> Ref<...Playback>`
- `AudioStreamGeneratorPlayback::push_buffer(PackedVector2Array) -> bool`
- `AudioStreamGeneratorPlayback::can_push_buffer(int)`
- `AudioStreamGeneratorPlayback::get_frames_available() -> int` — **FREE write room**, not data-in-buffer (matches engine; `attempt_to_feed_stream` relies on this)
- `AudioStreamGeneratorPlayback::get_skips() -> int` — overflow counter

Test-only API:
- `AudioStreamGeneratorPlayback::consume_test_frames(int) -> int` — drain N frames, return actual count
- `AudioStreamGeneratorPlayback::consume_test_frames_into(int) -> PackedVector2Array` — drain + return for inspection

Both simulate the audio thread's speaker drain that the test binary doesn't have.

## Smoke test (now three passes end-to-end)

```
audio_model smoke: capture round-trip OK (100 frames bit-exact)
audio_model smoke: playback capacity = 8192 frames (170.7 ms)
audio_model smoke: after push 480: frames_available = 7711, skips = 0
audio_model smoke: playback round-trip OK (480 frames bit-exact + overflow skip detected)
```

The playback test does three things:
1. Push 480 frames (one 10ms voice packet at 48 kHz) — verifies `push_buffer` accepts a fresh ring.
2. Drain and verify byte-for-byte preservation.
3. Force an overflow with a `cap + 100` payload — verifies `push_buffer` returns false AND `get_skips()` increments.

## Hierarchy flattening

The engine has `Resource → AudioStream → AudioStreamGenerator` and `RefCounted → AudioStreamPlayback → AudioStreamPlaybackResampled → AudioStreamGeneratorPlayback`. We flatten — both intermediate classes are skipped since godot-speech only calls the leaf API. Documented in the header comment.

## Test plan

- [x] `cmake --build build` clean (one inherited engine deprecation warning)
- [x] `./build/godot_audio_model_smoke` — all three pass-3/4/5 layers green
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean

## Out of scope

- **Pass 6**: `AudioStreamPlayer`/`Player2D`/`Player3D` wrappers + the `cast_to` / `call("get_stream_playback")` polymorphism
- **Pass 7**: link `speech.cpp` / `speech_processor.cpp` / `speech_decoder.cpp` against the model