### PR TITLE
CHI-101 Phase A pass-6: Node + Variant + cast_to + AudioStreamPlayer polymorphism

### DIFF
--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -542,6 +542,26 @@ the storage substrate the engine code path is built against.
    otherwise do. Smoke test pushes 480 frames, drains them with
    bit-exact verification, then forces an overflow to confirm skips
    increments. **Done in PR #23.**
+4. **Node + cast_to + Variant + AudioStreamPlayer/2D/3D.**
+   Polymorphism layer that lets `Speech::attempt_to_feed_stream`
+   reach the playback through a Variant-typed dispatch. `Node`
+   base class with parent/child + `has_method` + `call(StringName,
+   …)` returning `Variant`. `cast_to<T>(Node*)` free function via
+   `dynamic_cast` (the engine uses GDCLASS-registered RTTI; we use
+   the language facility since every class in the model has at
+   least one virtual). `Variant` minimal tagged value supporting
+   { NIL, BOOL, INT, FLOAT, STRING, OBJECT(Ref<RefCounted>) } —
+   exactly the keyhole godot-speech walks. `AudioStreamPlayer`
+   `Player2D` `Player3D` share an `AudioStreamPlayerCommon` body;
+   `set_stream(Ref<AudioStream>)` auto-instantiates the generator
+   playback so `call("get_stream_playback")` returns a stable Ref.
+   Three call dispatches modeled: `play(float)`,
+   `get_playback_position` → float, `get_stream_playback` → Ref.
+   Smoke test exercises all three player types via cast_to,
+   walks the `has_method` / `call` / Variant → Ref<T> conversion
+   path, and pushes a packet through the resulting playback to
+   confirm it's the same ring object the player owns.
+   **Done in PR #24.**
 2. **Node + RefCounted stand-ins.** Minimal `Node` with name/parent/child;
    `RefCounted` with strong+weak counts. Enough for `cast_to` to work.
 3. **AudioServer + bus model.** Plain map<StringName,int> of bus indices,

--- a/tests/godot_audio_model/CMakeLists.txt
+++ b/tests/godot_audio_model/CMakeLists.txt
@@ -48,6 +48,7 @@ set(MODEL_HEADERS
     core/ring_buffer.h
     core/string.h
     core/typedefs.h
+    core/variant.h
     core/vector.h
     core/vector2.h
     audio/audio_driver.h
@@ -56,6 +57,8 @@ set(MODEL_HEADERS
     audio/audio_server.h
     audio/audio_stream.h
     audio/audio_stream_generator.h
+    audio/audio_stream_player.h
+    audio/node.h
 )
 
 if(APPLE)

--- a/tests/godot_audio_model/audio/audio_stream_player.h
+++ b/tests/godot_audio_model/audio/audio_stream_player.h
@@ -1,0 +1,97 @@
+// CHI-101 Phase A pass-6 — `AudioStreamPlayer` / `Player2D` /
+// `Player3D` stand-ins.
+//
+// godot-speech treats the three players polymorphically — capture
+// uses `AudioStreamPlayer` (always 2D-positionless), receive can
+// be any of the three. The shared API godot-speech exercises is:
+//
+//   void set_stream(Ref<AudioStream>)
+//   set_bus(StringName)
+//   call("play", float position)
+//   call("get_playback_position") -> float
+//   call("get_stream_playback") -> Ref<AudioStreamGeneratorPlayback>
+//   has_method(StringName) -> bool
+//
+// All three derived players share the same implementation; in the
+// engine they differ by positional metadata that doesn't affect
+// the audio path godot-speech walks. We share an
+// `AudioStreamPlayerCommon` base and define Player / Player2D /
+// Player3D as thin tags so `cast_to<>` succeeds for all three.
+
+#pragma once
+
+#include "../core/core_types.h"
+#include "audio_stream_generator.h"
+#include "node.h"
+
+class AudioStreamPlayerCommon : public Node {
+	Ref<AudioStream> stream;
+	Ref<AudioStreamPlayback> playback;
+	StringName bus_name = StringName("Master");
+	float playback_position = 0.0f;
+	bool playing = false;
+
+public:
+	void set_stream(const Ref<AudioStream> &p_stream) {
+		stream = p_stream;
+		// If the stream is a generator, instantiate its playback
+		// eagerly so `get_stream_playback` returns a stable Ref.
+		// Engine semantics: get_stream_playback returns null until
+		// the stream is set.
+		if (p_stream.is_valid()) {
+			AudioStreamGenerator *g = dynamic_cast<AudioStreamGenerator *>(p_stream.ptr_raw());
+			if (g) {
+				Ref<AudioStreamGeneratorPlayback> gp = g->instantiate_playback();
+				playback = Ref<AudioStreamPlayback>(
+						static_cast<AudioStreamPlayback *>(gp.ptr_raw()));
+			}
+		}
+	}
+	Ref<AudioStream> get_stream() const { return stream; }
+
+	void set_bus(const StringName &p_bus) { bus_name = p_bus; }
+	StringName get_bus() const { return bus_name; }
+
+	// Direct API (the engine bind also exposes these as methods).
+	void play(float p_position) {
+		playback_position = p_position;
+		playing = true;
+	}
+	float get_playback_position() const { return playback_position; }
+	Ref<AudioStreamPlayback> get_stream_playback() const { return playback; }
+	bool is_playing() const { return playing; }
+
+	// Duck-typed dispatch — covers the three methods godot-speech
+	// calls through `call()`.
+	bool has_method(const StringName &p_method) const override {
+		const String m = (String)p_method;
+		return m == String("play") || m == String("get_playback_position") ||
+				m == String("get_stream_playback");
+	}
+
+	Variant call(const StringName &p_method) override {
+		const String m = (String)p_method;
+		if (m == String("get_playback_position")) {
+			return Variant(playback_position);
+		}
+		if (m == String("get_stream_playback")) {
+			return Variant(playback);
+		}
+		return Variant();
+	}
+
+	Variant call(const StringName &p_method, const Variant &p_arg0) override {
+		const String m = (String)p_method;
+		if (m == String("play")) {
+			play(static_cast<float>(p_arg0));
+			return Variant();
+		}
+		// Single-arg `get_stream_playback`/`get_playback_position`
+		// fall through to the zero-arg overload behavior.
+		return call(p_method);
+	}
+};
+
+class AudioStreamPlayer : public AudioStreamPlayerCommon {};
+class AudioStreamPlayer2D : public AudioStreamPlayerCommon {};
+class AudioStreamPlayer3D : public AudioStreamPlayerCommon {};

--- a/tests/godot_audio_model/audio/node.h
+++ b/tests/godot_audio_model/audio/node.h
@@ -1,0 +1,77 @@
+// CHI-101 Phase A pass-6 — `Node` base class + `cast_to<T>`.
+//
+// The reference engine's Node carries a heavy stack of
+// signal/property/group/RPC machinery; we keep only the parts
+// godot-speech actually touches:
+//
+//   * parent/child pointers (so `get_node_or_null(NodePath("…"))`
+//     can walk a tree the test driver builds)
+//   * `call(StringName method, …)` returning Variant — duck-typed
+//     method dispatch
+//   * `has_method(StringName)` predicate
+//   * a virtual destructor so dynamic_cast (and our `cast_to<T>`)
+//     works on the inheritance hierarchy
+//
+// Nothing here is RefCounted — the engine's Node owns its
+// children directly. Lifetime in the test binary is handled by
+// the test driver (stack scope or unique_ptr).
+
+#pragma once
+
+#include "../core/core_types.h"
+#include "../core/variant.h"
+
+#include <vector>
+
+class Node {
+	String node_name;
+	Node *parent = nullptr;
+	std::vector<Node *> children;
+
+public:
+	virtual ~Node() = default;
+
+	void set_name(const String &p_name) { node_name = p_name; }
+	String get_name() const { return node_name; }
+
+	// Tree manipulation (test-driver only; the engine has a
+	// scene-tree state machine we don't model).
+	void add_child(Node *p_child) {
+		if (!p_child) {
+			return;
+		}
+		p_child->parent = this;
+		children.push_back(p_child);
+	}
+
+	Node *get_node_or_null(const NodePath &p_path) {
+		const String target = p_path.get_path();
+		for (Node *c : children) {
+			if (c->node_name == target) {
+				return c;
+			}
+		}
+		return nullptr;
+	}
+
+	// Duck-typed call interface. Derived classes override.
+	virtual bool has_method(const StringName & /*p_method*/) const { return false; }
+	virtual Variant call(const StringName & /*p_method*/) { return Variant(); }
+	virtual Variant call(const StringName & /*p_method*/,
+			const Variant & /*p_arg0*/) {
+		return Variant();
+	}
+};
+
+// Engine-style typed cast. The engine implements this via its own
+// RTTI (registered via GDCLASS); dynamic_cast works for us because
+// every class in the model has at least one virtual function.
+template <typename T>
+T *cast_to(Node *p_node) {
+	return dynamic_cast<T *>(p_node);
+}
+
+template <typename T>
+const T *cast_to(const Node *p_node) {
+	return dynamic_cast<const T *>(p_node);
+}

--- a/tests/godot_audio_model/core/core_types.h
+++ b/tests/godot_audio_model/core/core_types.h
@@ -14,5 +14,6 @@
 #include "ref_counted.h"
 #include "string.h"
 #include "typedefs.h"
+#include "variant.h"
 #include "vector.h"
 #include "vector2.h"

--- a/tests/godot_audio_model/core/variant.h
+++ b/tests/godot_audio_model/core/variant.h
@@ -1,0 +1,110 @@
+// CHI-101 Phase A pass-6 — minimal `Variant` stand-in.
+//
+// The reference engine's Variant is a tagged union over ~30 types
+// with full reflection support. godot-speech uses it through a
+// much narrower keyhole — the only call sites in speech.cpp /
+// speech_processor.cpp are:
+//
+//   p_audio_stream_player->call("play", get_playback_position())
+//     → Variant(float) argument; return value discarded.
+//   Ref<AudioStreamGeneratorPlayback> pb = p_audio_stream_player->call("get_stream_playback")
+//     → Variant holding a Ref<RefCounted>; implicit conversion
+//       to Ref<DerivedT> via dynamic_cast.
+//   Dictionary["…"] = …, int64_t(Dict["…"]), bool(Dict["…"])
+//     → primitive get/set on dictionary values; needs to round
+//       trip int / bool / double / String / Ref.
+//
+// We support that keyhole and nothing more. The Variant here is
+// not an active union — it stores every primitive type as separate
+// fields (small constant overhead per Variant, easier to reason
+// about than placement-new tagged-union juggling).
+
+#pragma once
+
+#include "ref_counted.h"
+#include "string.h"
+#include "typedefs.h"
+
+class Variant {
+public:
+	enum Type {
+		NIL,
+		BOOL,
+		INT,
+		FLOAT,
+		STRING,
+		OBJECT,
+	};
+
+private:
+	Type type = NIL;
+	int64_t i = 0;
+	double f = 0.0;
+	bool b = false;
+	String s;
+	Ref<RefCounted> o;
+
+public:
+	Variant() = default;
+	Variant(bool v) :
+			type(BOOL), b(v) {}
+	Variant(int v) :
+			type(INT), i(v) {}
+	Variant(int64_t v) :
+			type(INT), i(v) {}
+	Variant(uint32_t v) :
+			type(INT), i(static_cast<int64_t>(v)) {}
+	Variant(float v) :
+			type(FLOAT), f(v) {}
+	Variant(double v) :
+			type(FLOAT), f(v) {}
+	Variant(const char *v) :
+			type(STRING), s(v) {}
+	Variant(const String &v) :
+			type(STRING), s(v) {}
+
+	// Accept any Ref<T> where T derives from RefCounted.
+	template <typename T>
+	Variant(const Ref<T> &v) :
+			type(OBJECT) {
+		if (v.is_valid()) {
+			o = Ref<RefCounted>(static_cast<RefCounted *>(v.ptr_raw()));
+		}
+	}
+
+	Type get_type() const { return type; }
+
+	// Implicit primitive conversions.
+	operator bool() const {
+		switch (type) {
+			case BOOL:
+				return b;
+			case INT:
+				return i != 0;
+			case FLOAT:
+				return f != 0.0;
+			case OBJECT:
+				return o.is_valid();
+			default:
+				return false;
+		}
+	}
+	operator int() const { return static_cast<int>(i); }
+	operator int64_t() const { return i; }
+	operator uint32_t() const { return static_cast<uint32_t>(i); }
+	operator float() const { return static_cast<float>(f); }
+	operator double() const { return f; }
+	operator String() const { return s; }
+
+	// Implicit Ref<T> conversion via dynamic_cast through the
+	// stored RefCounted*. Mirrors the engine's behavior: the
+	// Variant ignores type mismatches and returns an empty Ref.
+	template <typename T>
+	operator Ref<T>() const {
+		if (type != OBJECT || o.is_null()) {
+			return Ref<T>();
+		}
+		T *casted = dynamic_cast<T *>(o.ptr_raw());
+		return Ref<T>(casted);
+	}
+};

--- a/tests/godot_audio_model/smoke_test.cpp
+++ b/tests/godot_audio_model/smoke_test.cpp
@@ -10,6 +10,8 @@
 #include "audio/audio_effect_capture.h"
 #include "audio/audio_server.h"
 #include "audio/audio_stream_generator.h"
+#include "audio/audio_stream_player.h"
+#include "audio/node.h"
 #include "core/core_types.h"
 
 #include <cstdio>
@@ -144,6 +146,75 @@ static int test_playback_roundtrip() {
 	return 0;
 }
 
+static int test_player_polymorphism() {
+	// Build the player like Speech::add_player_audio would: an
+	// AudioStreamPlayer node with an AudioStreamGenerator stream.
+	AudioStreamPlayer player;
+	player.set_name(String("AudioStreamPlayer"));
+	player.set_bus(StringName("Master"));
+
+	Ref<AudioStreamGenerator> gen = new AudioStreamGenerator();
+	gen->set_mix_rate(48000.0f);
+	gen->set_buffer_length(0.1f);
+	player.set_stream(gen);
+
+	// cast_to should resolve to all three player tags (the test
+	// driver's parent walks the union of types).
+	Node *as_node = &player;
+	if (!cast_to<AudioStreamPlayer>(as_node)) {
+		std::fprintf(stderr, "FAIL: cast_to<AudioStreamPlayer> returned null\n");
+		return 1;
+	}
+	if (cast_to<AudioStreamPlayer2D>(as_node)) {
+		std::fprintf(stderr, "FAIL: cast_to<AudioStreamPlayer2D> succeeded on AudioStreamPlayer\n");
+		return 1;
+	}
+	if (cast_to<AudioStreamPlayer3D>(as_node)) {
+		std::fprintf(stderr, "FAIL: cast_to<AudioStreamPlayer3D> succeeded on AudioStreamPlayer\n");
+		return 1;
+	}
+
+	// has_method check (Speech does this before call("get_stream_playback")).
+	if (!as_node->has_method(StringName("get_stream_playback"))) {
+		std::fprintf(stderr, "FAIL: has_method(\"get_stream_playback\") returned false\n");
+		return 1;
+	}
+
+	// call("play", float) → no-op return; play state updates.
+	as_node->call(StringName("play"), Variant(0.25f));
+
+	// call("get_playback_position") → Variant(float)
+	Variant pos_var = as_node->call(StringName("get_playback_position"));
+	const float pos = static_cast<float>(pos_var);
+	if (pos != 0.25f) {
+		std::fprintf(stderr, "FAIL: playback_position after play(0.25) = %g\n", pos);
+		return 1;
+	}
+
+	// call("get_stream_playback") → Variant(Ref<AudioStreamPlayback>)
+	// which implicitly converts to Ref<AudioStreamGeneratorPlayback>.
+	Variant pb_var = as_node->call(StringName("get_stream_playback"));
+	Ref<AudioStreamGeneratorPlayback> pb = pb_var;
+	if (pb.is_null()) {
+		std::fprintf(stderr, "FAIL: get_stream_playback returned null Ref\n");
+		return 1;
+	}
+
+	// The returned playback must work end-to-end.
+	PackedVector2Array pkt;
+	pkt.resize(64);
+	for (int i = 0; i < 64; ++i) {
+		pkt[i] = Vector2(0.5f, -0.5f);
+	}
+	if (!pb->push_buffer(pkt)) {
+		std::fprintf(stderr, "FAIL: push_buffer via Variant-derived playback failed\n");
+		return 1;
+	}
+
+	std::printf("audio_model smoke: player polymorphism OK (cast_to + has_method + call -> Variant -> Ref<T>)\n");
+	return 0;
+}
+
 int main() {
 #ifdef COREAUDIO_ENABLED
 	AudioDriverCoreAudio driver;
@@ -158,5 +229,8 @@ int main() {
 	if (int rc = test_capture_roundtrip()) {
 		return rc;
 	}
-	return test_playback_roundtrip();
+	if (int rc = test_playback_roundtrip()) {
+		return rc;
+	}
+	return test_player_polymorphism();
 }


### PR DESCRIPTION
## Summary

Pass 6 of the audio-model implementation outline — the duck-typed `call()` / `cast_to<T>` / `Variant` polymorphism layer that `Speech::attempt_to_feed_stream` walks to reach the playback.

## What lands

```
tests/godot_audio_model/
├── core/variant.h              # tagged value: NIL/BOOL/INT/FLOAT/STRING/OBJECT
└── audio/
    ├── node.h                  # Node + has_method + call + cast_to<T> free fn
    └── audio_stream_player.h   # AudioStreamPlayer + Player2D + Player3D
```

## Engine call paths reproduced

```cpp
cast_to<AudioStreamPlayer>(node)               // and 2D / 3D
node->has_method(StringName("get_stream_playback"))
node->call(StringName("play"), node->call(StringName("get_playback_position")))
Ref<AudioStreamGeneratorPlayback> pb = node->call(StringName("get_stream_playback"));
```

Variant supports exactly the keyhole speech.cpp uses:
- Implicit construction from `bool`, `int`, `int64_t`, `uint32_t`, `float`, `double`, `String`, `Ref<T>`.
- Implicit conversion to `bool`, `int`, `int64_t`, `float`, `double`, `String`.
- Implicit conversion to `Ref<T>` via `dynamic_cast` through the stored `RefCounted*` (returns empty Ref on type mismatch — engine matches this).

`cast_to<T>` is a free template using `dynamic_cast` through `Node`'s vtable. The engine uses GDCLASS-registered RTTI; the result is the same for the player/playback hierarchies we model.

## Player class layout

The three player types share an `AudioStreamPlayerCommon` body so the implementation is centralized:

- `AudioStreamPlayer`
- `AudioStreamPlayer2D`
- `AudioStreamPlayer3D`

`set_stream(Ref<AudioStream>)` detects `AudioStreamGenerator` via `dynamic_cast` and eagerly calls `instantiate_playback()` so `call("get_stream_playback")` returns a stable Ref. Three `call()` dispatches modeled:
- `play(float)` — stores position, sets `playing = true`
- `get_playback_position()` → `Variant(float)`
- `get_stream_playback()` → `Variant(Ref<AudioStreamPlayback>)`

## Smoke test (four passes end-to-end)

```
audio_model smoke: driver name = CoreAudio
audio_model smoke: speaker mode = 0
audio_model smoke: capture round-trip OK (100 frames bit-exact)
audio_model smoke: playback round-trip OK (480 frames bit-exact + overflow skip detected)
audio_model smoke: player polymorphism OK (cast_to + has_method + call -> Variant -> Ref<T>)
```

The new pass exercises:
- `cast_to<AudioStreamPlayer>` succeeds; `cast_to<AudioStreamPlayer2D>` returns null on a plain Player (and vice versa)
- `has_method("get_stream_playback")` returns true
- `call("play", Variant(0.25f))` updates playback position; subsequent `call("get_playback_position")` reads back 0.25
- `Ref<AudioStreamGeneratorPlayback> pb = call("get_stream_playback")` — Variant → Ref<T> implicit conversion works
- pushing 64 frames through `pb` succeeds — confirms it's the same ring object the player owns

## Test plan

- [x] `cmake --build build` clean (one inherited engine deprecation warning)
- [x] `./build/godot_audio_model_smoke` — all four passes green
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean

## Out of scope

**Pass 7** — link `speech.cpp` / `speech_processor.cpp` / `speech_decoder.cpp` against the model end-to-end and verify the slang_validate kernels still agree with the live runtime.