### PR TITLE
CHI-101 Phase A pass-7b: link speech_processor.cpp + end-to-end Opus round-trip

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -93,6 +93,10 @@ jobs:
         working-directory: tests/godot_audio_model
         run: ./build/godot_audio_model_decoder_smoke
 
+      - name: Smoke test (processor encode -> decode round-trip)
+        working-directory: tests/godot_audio_model
+        run: ./build/godot_audio_model_processor_smoke
+
   audio_model_linux:
     name: Audio model (Linux, no CoreAudio)
     runs-on: ubuntu-latest
@@ -120,3 +124,7 @@ jobs:
       - name: Smoke test (decoder linked against model)
         working-directory: tests/godot_audio_model
         run: ./build/godot_audio_model_decoder_smoke
+
+      - name: Smoke test (processor encode -> decode round-trip)
+        working-directory: tests/godot_audio_model
+        run: ./build/godot_audio_model_processor_smoke

--- a/manuals/decisions/2026-05-12-speech-isolation.md
+++ b/manuals/decisions/2026-05-12-speech-isolation.md
@@ -580,6 +580,35 @@ filesystem. Engine code stays unedited.
    otherwise do. Smoke test pushes 480 frames, drains them with
    bit-exact verification, then forces an overflow to confirm skips
    increments. **Done in PR #23.**
+7b. **Link speech_processor.cpp against the model + end-to-end
+    Opus round-trip.** Build on pass-7a: extend Variant with
+    `PackedByteArray` carrier + matching operator=. Add
+    `ProjectSettings::get_singleton()->get(...)` to the shim layer.
+    Add `set_process`, `set_physics_process`, `set_process_input`,
+    `NOTIFICATION_READY/ENTER_TREE/EXIT_TREE/PROCESS` free helpers
+    to Node so the engine's `_notification` switch compiles. Add
+    `vformat`, `SNAME`, `real_t`. Add `Ref<T>::ptr()` (engine
+    accessor; rename the storage member to `_ref` to avoid the
+    method/field name collision) and `Ref<T>::instantiate()`. Add
+    `Variant::DICTIONARY`/`ARRAY`/`PACKED_BYTE_ARRAY` enum values
+    so PropertyInfo declarations parse. The `speech_lib/`
+    CMake target now compiles **`speech_processor.cpp`** alongside
+    `speech_decoder.cpp` into `libspeech_engine.a`. A new
+    `processor_smoke_test.cpp` drives a 440 Hz tone through the
+    real `SpeechProcessor::encode_buffer`, then decodes the
+    resulting Opus packet through `SpeechDecoder::process`, and
+    asserts the decoder returns the full 480-sample frame count.
+    Output:
+    ```
+    processor_smoke: SpeechProcessor constructed
+    processor_smoke: encode_buffer wrote 71 bytes (negative = Opus error)
+    processor_smoke: PASS — Opus emitted 71-byte compressed packet
+    processor_smoke: decoder->process returned 480 (positive = frames decoded)
+    processor_smoke: PASS — Opus encode -> decode round-trip ran end-to-end
+    ```
+    CI runs the new smoke test on both macOS and Linux. Done in
+    PR #27.
+
 7a. **Link speech_decoder.cpp against the model.** Add `Dictionary`
     + `Array` core types (std::map + std::vector backed; mirror
     the engine's `has` / `[]` / `size` / `push_back` / `pop_front`

--- a/tests/godot_audio_model/CMakeLists.txt
+++ b/tests/godot_audio_model/CMakeLists.txt
@@ -132,3 +132,13 @@ target_link_libraries(godot_audio_model_decoder_smoke
     PRIVATE
         speech_engine
 )
+
+# Processor smoke (Pass 7b): exercises encode_buffer + a SpeechDecoder
+# round-trip end-to-end.
+add_executable(godot_audio_model_processor_smoke
+    processor_smoke_test.cpp
+)
+target_link_libraries(godot_audio_model_processor_smoke
+    PRIVATE
+        speech_engine
+)

--- a/tests/godot_audio_model/audio/audio_stream_player.h
+++ b/tests/godot_audio_model/audio/audio_stream_player.h
@@ -53,9 +53,13 @@ public:
 	StringName get_bus() const { return bus_name; }
 
 	// Direct API (the engine bind also exposes these as methods).
-	void play(float p_position) {
+	void play(float p_position = 0.0f) {
 		playback_position = p_position;
 		playing = true;
+	}
+	void stop() {
+		playing = false;
+		playback_position = 0.0f;
 	}
 	float get_playback_position() const { return playback_position; }
 	Ref<AudioStreamPlayback> get_stream_playback() const { return playback; }

--- a/tests/godot_audio_model/audio/node.h
+++ b/tests/godot_audio_model/audio/node.h
@@ -61,7 +61,40 @@ public:
 			const Variant & /*p_arg0*/) {
 		return Variant();
 	}
+
+	// `emit_signal` — engine fans the signal out to connected
+	// handlers. The test path has no signal listeners (the engine
+	// scene graph isn't running); we accept the call as a no-op
+	// and silently drop the payload. If a future test needs to
+	// observe emitted signals, route via a per-Node callback list.
+	template <typename... Args>
+	void emit_signal(const StringName & /*p_name*/, Args &&...) const {}
+
+	// `_notification(int p_what)` — virtual lifecycle hook the
+	// engine calls during scene-tree state changes. Test path
+	// drives this manually when needed.
+	virtual void _notification(int /*p_what*/) {}
 };
+
+// Engine NOTIFICATION_* constants — the few godot-speech reacts to.
+enum {
+	NOTIFICATION_ENTER_TREE = 10,
+	NOTIFICATION_READY = 11,
+	NOTIFICATION_EXIT_TREE = 12,
+	NOTIFICATION_PROCESS = 13,
+	NOTIFICATION_PHYSICS_PROCESS = 14,
+	NOTIFICATION_INTERNAL_PROCESS = 15,
+};
+
+// Node lifecycle setters — engine controls whether `_notification`
+// fires per-frame. Test path drives manually; setters are no-ops.
+inline void set_process(bool /*p_active*/) {}
+inline void set_physics_process(bool /*p_active*/) {}
+inline void set_process_input(bool /*p_active*/) {}
+
+// `real_t` — engine's switchable float/double precision type. We
+// fix it to float since the model is fp32 throughout.
+using real_t = float;
 
 // Engine-style typed cast. The engine implements this via its own
 // RTTI (registered via GDCLASS); dynamic_cast works for us because

--- a/tests/godot_audio_model/core/ref_counted.h
+++ b/tests/godot_audio_model/core/ref_counted.h
@@ -1,4 +1,4 @@
-// CHI-101 Phase A pass-3 — `RefCounted` + `Ref<T>` stand-ins.
+// CHI-101 Phase A — `RefCounted` + `Ref<T>` stand-ins.
 //
 // Same idea as core/object/ref_counted.h: an intrusive ref-count on
 // the pointee, and a `Ref<T>` smart pointer that increments/
@@ -29,66 +29,93 @@ public:
 
 template <typename T>
 class Ref {
-	T *ptr = nullptr;
+	// Storage. The member is named `_ref` to free the `ptr` and
+	// `ptr_raw` identifiers for the engine-style accessor methods.
+	T *_ref = nullptr;
 
 public:
 	Ref() = default;
 	Ref(T *p) :
-			ptr(p) {
-		if (ptr)
-			ptr->reference();
+			_ref(p) {
+		if (_ref) {
+			_ref->reference();
+		}
 	}
 	Ref(const Ref &o) :
-			ptr(o.ptr) {
-		if (ptr)
-			ptr->reference();
+			_ref(o._ref) {
+		if (_ref) {
+			_ref->reference();
+		}
 	}
 
 	template <typename U>
 	Ref(const Ref<U> &o) :
-			ptr(static_cast<T *>(o.ptr_raw())) {
-		if (ptr)
-			ptr->reference();
+			_ref(static_cast<T *>(o.ptr_raw())) {
+		if (_ref) {
+			_ref->reference();
+		}
 	}
 
 	~Ref() {
-		if (ptr && ptr->unreference()) {
-			delete ptr;
+		if (_ref && _ref->unreference()) {
+			delete _ref;
 		}
 	}
 
 	Ref &operator=(const Ref &o) {
-		if (this == &o)
+		if (this == &o) {
 			return *this;
-		if (o.ptr)
-			o.ptr->reference();
-		if (ptr && ptr->unreference())
-			delete ptr;
-		ptr = o.ptr;
+		}
+		if (o._ref) {
+			o._ref->reference();
+		}
+		if (_ref && _ref->unreference()) {
+			delete _ref;
+		}
+		_ref = o._ref;
 		return *this;
 	}
 
 	Ref &operator=(T *p) {
-		if (p)
+		if (p) {
 			p->reference();
-		if (ptr && ptr->unreference())
-			delete ptr;
-		ptr = p;
+		}
+		if (_ref && _ref->unreference()) {
+			delete _ref;
+		}
+		_ref = p;
 		return *this;
 	}
 
-	T *operator->() const { return ptr; }
-	T &operator*() const { return *ptr; }
-	T *ptr_raw() const { return ptr; }
+	T *operator->() const { return _ref; }
+	T &operator*() const { return *_ref; }
 
-	bool is_valid() const { return ptr != nullptr; }
-	bool is_null() const { return ptr == nullptr; }
-	void unref() {
-		if (ptr && ptr->unreference())
-			delete ptr;
-		ptr = nullptr;
+	// Engine API names: both ptr() and ptr_raw() return the raw
+	// pointer. The engine has only ptr(); we keep ptr_raw() too
+	// for backward compat with earlier pass code in the model.
+	T *ptr() const { return _ref; }
+	T *ptr_raw() const { return _ref; }
+
+	// Engine API: Ref<T>::instantiate() creates a new instance.
+	void instantiate() {
+		if (_ref && _ref->unreference()) {
+			delete _ref;
+		}
+		_ref = new T();
+		if (_ref) {
+			_ref->reference();
+		}
 	}
 
-	bool operator==(const Ref &o) const { return ptr == o.ptr; }
-	bool operator!=(const Ref &o) const { return ptr != o.ptr; }
+	bool is_valid() const { return _ref != nullptr; }
+	bool is_null() const { return _ref == nullptr; }
+	void unref() {
+		if (_ref && _ref->unreference()) {
+			delete _ref;
+		}
+		_ref = nullptr;
+	}
+
+	bool operator==(const Ref &o) const { return _ref == o._ref; }
+	bool operator!=(const Ref &o) const { return _ref != o._ref; }
 };

--- a/tests/godot_audio_model/core/string.h
+++ b/tests/godot_audio_model/core/string.h
@@ -93,6 +93,68 @@ inline String operator+(const char *lhs, const String &rhs) {
 	return String(lhs) + rhs;
 }
 
+// `vformat(fmt, args...)` — engine's printf-ish String formatter.
+// Engine uses `String::sprintf` with Variant args; we forward to
+// snprintf and ignore type-checking. Sufficient for the few log
+// strings godot-speech builds with it.
+namespace _audio_model {
+inline String vformat_impl(const char *fmt) {
+	return String(fmt);
+}
+
+template <typename T>
+inline String vformat_impl(const char *fmt, T arg) {
+	char buf[256];
+	std::snprintf(buf, sizeof(buf), fmt, arg);
+	return String(buf);
+}
+
+inline const char *cstr_of(const String &s) {
+	return s.utf8().get_data();
+}
+inline const char *cstr_of(const char *s) {
+	return s;
+}
+} // namespace _audio_model
+
+// vformat with arbitrary args — Godot's signature accepts up to N
+// args of any printable type. We forward through snprintf.
+inline String vformat(const String &fmt) {
+	return fmt;
+}
+
+template <typename A>
+inline String vformat(const String &fmt, const A &a) {
+	(void)a;
+	// Replace each `%s` with the next arg via simple substitution.
+	// godot-speech uses %s with already-stringified arguments, so a
+	// single-pass single-arg replace is sufficient.
+	const std::string &src = fmt.std_str();
+	auto pos = src.find("%s");
+	if (pos == std::string::npos) {
+		return fmt;
+	}
+	String result(src.substr(0, pos));
+	if constexpr (std::is_same_v<A, String>) {
+		result = result + a;
+	} else if constexpr (std::is_same_v<A, const char *>) {
+		result = result + String(a);
+	} else {
+		result = result + itos(static_cast<long long>(a));
+	}
+	return result + String(src.substr(pos + 2));
+}
+
+template <typename A, typename B>
+inline String vformat(const String &fmt, const A &a, const B &b) {
+	return vformat(vformat(fmt, a), b);
+}
+
+// `SNAME("foo")` — the engine's compile-time StringName literal.
+// Inlines to a temporary StringName here; matches the value-level
+// behavior without the engine's static-cache optimization.
+#define SNAME(m_str) StringName(m_str)
+
 class StringName {
 	std::string s;
 

--- a/tests/godot_audio_model/core/variant.h
+++ b/tests/godot_audio_model/core/variant.h
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#include "packed_arrays.h"
 #include "ref_counted.h"
 #include "string.h"
 #include "typedefs.h"
+
+#include <memory>
 
 class Variant {
 public:
@@ -34,6 +37,10 @@ public:
 		FLOAT,
 		STRING,
 		OBJECT,
+		DICTIONARY,
+		ARRAY,
+		PACKED_BYTE_ARRAY,
+		PACKED_VECTOR2_ARRAY,
 	};
 
 private:
@@ -43,6 +50,13 @@ private:
 	bool b = false;
 	String s;
 	Ref<RefCounted> o;
+	// Heavy payloads carried via shared pointer so Variant remains
+	// small and copyable; the engine uses CoW + in-place storage.
+	std::shared_ptr<PackedByteArray> pba;
+	// PackedVector2Array isn't actually round-tripped through
+	// Variant in godot-speech (the engine binds it but it's never
+	// the rhs of `Variant = …`); declare a placeholder slot for
+	// completeness so the conversion path compiles.
 
 public:
 	Variant() = default;
@@ -62,6 +76,9 @@ public:
 			type(STRING), s(v) {}
 	Variant(const String &v) :
 			type(STRING), s(v) {}
+	Variant(const PackedByteArray &v) :
+			type(PACKED_BYTE_ARRAY),
+			pba(std::make_shared<PackedByteArray>(v)) {}
 
 	// Accept any Ref<T> where T derives from RefCounted.
 	template <typename T>
@@ -70,6 +87,53 @@ public:
 		if (v.is_valid()) {
 			o = Ref<RefCounted>(static_cast<RefCounted *>(v.ptr_raw()));
 		}
+	}
+
+	// Engine's Dictionary::operator[] returns a Variant&, which
+	// callers then assign to. The model uses std::map under the
+	// hood, so to match `dict["key"] = some_value` we need
+	// Variant's assignment to accept whatever the engine assigns.
+	// Implement via re-construction from the rhs.
+	Variant &operator=(bool v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(int v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(int64_t v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(uint32_t v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(const PackedByteArray &v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(float v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(double v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(const char *v) {
+		*this = Variant(v);
+		return *this;
+	}
+	Variant &operator=(const String &v) {
+		*this = Variant(v);
+		return *this;
+	}
+	template <typename T>
+	Variant &operator=(const Ref<T> &v) {
+		*this = Variant(v);
+		return *this;
 	}
 
 	Type get_type() const { return type; }
@@ -95,6 +159,9 @@ public:
 	operator float() const { return static_cast<float>(f); }
 	operator double() const { return f; }
 	operator String() const { return s; }
+	operator PackedByteArray() const {
+		return pba ? *pba : PackedByteArray();
+	}
 
 	// Implicit Ref<T> conversion via dynamic_cast through the
 	// stored RefCounted*. Mirrors the engine's behavior: the

--- a/tests/godot_audio_model/processor_smoke_test.cpp
+++ b/tests/godot_audio_model/processor_smoke_test.cpp
@@ -1,0 +1,71 @@
+// CHI-101 Phase A pass-7b smoke test — constructs a real
+// SpeechProcessor (from godot-speech/speech_processor.cpp) linked
+// against the audio model, drives a synthetic 480-sample voice
+// packet through `encode_buffer`, and verifies the output is a
+// nonzero Opus-compressed buffer.
+//
+// Doesn't exercise the full _mix_audio capture loop (that needs an
+// AudioEffectCapture + AudioServer + AudioStreamPlayer wired up;
+// pass-7c will land that). The encode-buffer path here proves
+// the Opus encoder side links and runs through the wrapper code
+// godot-speech writes.
+
+#include "../../speech_processor.h"
+
+#include <cmath>
+#include <cstdio>
+
+int main() {
+	SpeechProcessor processor;
+	std::printf("processor_smoke: SpeechProcessor constructed\n");
+
+	// Build a 480-sample (10 ms @ 48 kHz) PCM buffer with a soft tone.
+	// PCM is int16 stereo-like (single mono channel for this test).
+	PackedByteArray pcm_in;
+	const int frame_count = SpeechProcessor::SPEECH_SETTING_BUFFER_FRAME_COUNT;
+	pcm_in.resize(frame_count * static_cast<int>(SpeechProcessor::SPEECH_SETTING_BUFFER_BYTE_COUNT));
+
+	int16_t *pcm_ptr = reinterpret_cast<int16_t *>(pcm_in.ptrw());
+	for (int i = 0; i < frame_count; ++i) {
+		// 440 Hz tone at -12 dBFS — well within the encoder's range.
+		const double t = static_cast<double>(i) / static_cast<double>(SpeechProcessor::SPEECH_SETTING_SAMPLE_RATE);
+		pcm_ptr[i] = static_cast<int16_t>(std::sin(2.0 * 3.14159265358979 * 440.0 * t) * 8192.0);
+	}
+
+	PackedByteArray compressed;
+	compressed.resize(SpeechProcessor::SPEECH_SETTING_INTERNAL_BUFFER_SIZE);
+	int written = processor.encode_buffer(&pcm_in, &compressed);
+	std::printf("processor_smoke: encode_buffer wrote %d bytes (negative = Opus error)\n",
+			written);
+
+	if (written <= 0) {
+		std::fprintf(stderr, "FAIL: encode_buffer returned %d on a 440 Hz tone\n", written);
+		return 1;
+	}
+	std::printf("processor_smoke: PASS — Opus emitted %d-byte compressed packet\n", written);
+
+	// Round-trip through the decoder. Construct a SpeechDecoder via
+	// the processor's get_speech_decoder factory; engine path
+	// allocates the OpusDecoder.
+	Ref<SpeechDecoder> decoder = processor.get_speech_decoder();
+	if (decoder.is_null()) {
+		std::fprintf(stderr, "FAIL: get_speech_decoder returned null Ref\n");
+		return 1;
+	}
+
+	PackedByteArray pcm_out;
+	pcm_out.resize(frame_count * static_cast<int>(SpeechProcessor::SPEECH_SETTING_BUFFER_BYTE_COUNT));
+	int32_t decode_result = decoder->process(&compressed, &pcm_out,
+			written, pcm_out.size(), frame_count);
+	std::printf("processor_smoke: decoder->process returned %d (positive = frames decoded)\n",
+			decode_result);
+
+	if (decode_result != frame_count) {
+		std::fprintf(stderr, "FAIL: decoder returned %d frames, expected %d\n",
+				decode_result, frame_count);
+		return 1;
+	}
+
+	std::printf("processor_smoke: PASS — Opus encode -> decode round-trip ran end-to-end\n");
+	return 0;
+}

--- a/tests/godot_audio_model/shims/core/config/project_settings.h
+++ b/tests/godot_audio_model/shims/core/config/project_settings.h
@@ -1,9 +1,11 @@
-// CHI-101 Phase A pass-3 — engine-path shim. The CoreAudio driver
-// uses `GLOBAL_GET("…")` to read project settings (enable_input,
-// audio-driver tuning knobs). The reference engine resolves these
-// against `ProjectSettings::get_singleton()`; the test binary has
-// no project settings, so the macro returns hard-coded defaults
-// chosen to keep the driver in its "normal" mode.
+// CHI-101 Phase A pass-3/7b — engine-path shim. Provides
+// `ProjectSettings::get_singleton()->get(...)` and the engine
+// `GLOBAL_GET(...)` macro by routing both to a hard-coded
+// "audio/driver/enable_input = 1" + "everything else = 0" table.
+// The test binary has no real ProjectSettings; this just keeps the
+// godot-speech configuration-checks falling through to the engaged
+// path so capture initializes.
+
 #pragma once
 
 #include "../../../core/core_types.h"
@@ -11,14 +13,29 @@
 #include <cstring>
 
 namespace _audio_model {
-// Returns a default value for the few project-setting keys the
-// CoreAudio driver consults. Unknown keys return 0.
 inline int global_get_int(const char *key) {
 	if (std::strcmp(key, "audio/driver/enable_input") == 0) {
 		return 1; // capture path needs to be on for the speech tests
+	}
+	if (std::strcmp(key, "audio/enable_audio_input") == 0) {
+		return 1; // speech_processor::start() checks this
 	}
 	return 0;
 }
 } // namespace _audio_model
 
 #define GLOBAL_GET(m_key) (_audio_model::global_get_int(m_key))
+
+class ProjectSettings {
+	static ProjectSettings instance;
+
+public:
+	static ProjectSettings *get_singleton() { return &instance; }
+
+	Variant get(const String &key) const {
+		return Variant(_audio_model::global_get_int(key.utf8().get_data()));
+	}
+	Variant get(const char *key) const { return get(String(key)); }
+};
+
+inline ProjectSettings ProjectSettings::instance{};

--- a/tests/godot_audio_model/speech_lib/CMakeLists.txt
+++ b/tests/godot_audio_model/speech_lib/CMakeLists.txt
@@ -22,6 +22,7 @@ pkg_check_modules(SAMPLERATE REQUIRED samplerate)
 
 add_library(speech_engine STATIC
     ${SPEECH_ROOT}/speech_decoder.cpp
+    ${SPEECH_ROOT}/speech_processor.cpp
 )
 
 target_include_directories(speech_engine


### PR DESCRIPTION
## Summary

Second sub-pass of the link-the-engine-sources work. `speech_processor.cpp` (501 LOC) now compiles and links against the audio model alongside `speech_decoder.cpp`. The new processor smoke test drives a **real Opus encode → decode round-trip** through the godot-speech engine code:

```
$ ./build/godot_audio_model_processor_smoke
processor_smoke: SpeechProcessor constructed
processor_smoke: encode_buffer wrote 71 bytes (negative = Opus error)
processor_smoke: PASS — Opus emitted 71-byte compressed packet
processor_smoke: decoder->process returned 480 (positive = frames decoded)
processor_smoke: PASS — Opus encode -> decode round-trip ran end-to-end
```

A 440 Hz tone PCM packet goes into the real `SpeechProcessor::encode_buffer`, Opus produces a 71-byte compressed payload, and `SpeechDecoder::process` decodes it back to a full 480-sample frame.

## Model surface added

**Variant:**
- `PackedByteArray` carrier (shared_ptr-backed) + ctor + operator=
- `DICTIONARY` / `ARRAY` / `PACKED_BYTE_ARRAY` enum tags
- `uint32_t` operator= overload (resolves prior int/int64_t ambiguity)

**Ref<T>:**
- `ptr()` public accessor — member storage renamed from `ptr` to `_ref` to avoid the method/field name collision
- `instantiate()` factory matching engine's API

**Node:**
- `emit_signal(StringName, ...)` no-op
- `_notification(int)` virtual hook
- `NOTIFICATION_READY / ENTER_TREE / EXIT_TREE / PROCESS / ...` enum
- `set_process / set_physics_process / set_process_input` free helpers
- `real_t` typedef → `float`

**AudioStreamPlayer:**
- Default-arg `play(float p_position = 0.0f)` (engine signature)
- `stop()`

**String:**
- `vformat(fmt, args...)` — printf-ish String formatter
- `SNAME(str)` macro → `StringName(str)`

**shims/core/config/project_settings.h:**
- `ProjectSettings::get_singleton()->get(...)` returning Variant
- Default table: `audio/driver/enable_input = 1`, `audio/enable_audio_input = 1`

## CI

The new `godot_audio_model_processor_smoke` runs on both macOS and Linux runners — same encode/decode round-trip on both platforms.

## Out of scope (pass 7c)

`speech.cpp` (850 LOC) — full receive + jitter buffer path. Pulls in:
- `SceneTree` + `MultiplayerAPI` (`get_tree()`, `get_multiplayer()`, `has_multiplayer_peer()`, `get_unique_id()`, `get_remote_sender_id()`)
- `get_node_or_null` chains for finding the player node by path
- `cast_to<AudioStreamPlayer2D>` / `cast_to<AudioStreamPlayer3D>`
- Variant `call("get_stream_playback")` flow that pass 6 modeled — exercised end-to-end for the first time

## Test plan

- [x] `cmake --build build` clean on macOS (one inherited engine deprecation warning)
- [x] `./build/godot_audio_model_processor_smoke` PASS
- [x] `./build/godot_audio_model_decoder_smoke` PASS
- [x] `./build/godot_audio_model_smoke` (all four prior passes still green)
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean