### PR TITLE
fix(audio_model): add itos(long) overload for Linux int64_t resolution

### DIFF
--- a/tests/godot_audio_model/core/string.h
+++ b/tests/godot_audio_model/core/string.h
@@ -73,14 +73,23 @@ public:
 	}
 };
 
-// `itos` mirrors Godot's int-to-String helper.
+// `itos` mirrors Godot's int-to-String helper. Linux's GCC aliases
+// `int64_t` to `long` (not `long long`), and macOS's clang aliases
+// it to `long long` — both overloads need to exist to resolve
+// without ambiguity across platforms.
 inline String itos(long long v) {
+	return String(std::to_string(v));
+}
+inline String itos(long v) {
 	return String(std::to_string(v));
 }
 inline String itos(int v) {
 	return String(std::to_string(v));
 }
 inline String itos(unsigned int v) {
+	return String(std::to_string(v));
+}
+inline String itos(unsigned long v) {
 	return String(std::to_string(v));
 }
 inline String itos(unsigned long long v) {


### PR DESCRIPTION
## Summary

Linux GCC aliases `int64_t` to `long` (not `long long`), so the existing `itos(long long)` + `itos(int)` overload pair didn't resolve `itos(static_cast<int64_t>(key))` without ambiguity. macOS clang aliases `int64_t` to `long long` and accepted the same code.

Add explicit `itos(long)` and `itos(unsigned long)` overloads so calls resolve on both platforms.

## Background

Caught by the new `Audio model (Linux, no CoreAudio)` job on PR #28 — failure was non-blocking (job isn't in the required-checks list yet) so PR #28 merged with red Linux. This restores green Linux.

I'll add the Linux job to required checks in a follow-up `gh api` call.

## Test plan

- [x] Local: `cmake --build build` clean on macOS
- [x] All four smokes pass locally
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean