### PR TITLE
CHI-101 Phase A: vendor FTXUI v6.1.9 + first net_loopback smoke

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -67,6 +67,39 @@ jobs:
         working-directory: tests/slang_validate
         run: SLANGC="$SLANG_HOME/bin/slangc" make metal-discipline
 
+  net_loopback:
+    name: net_loopback (FTXUI vendor, ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cmake + ninja
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update
+            sudo apt-get install -y cmake ninja-build
+          else
+            brew install cmake ninja
+          fi
+        shell: bash
+
+      - name: Configure (FetchContent fetches FTXUI v6.1.9)
+        working-directory: tests/net_loopback
+        run: cmake -S . -B build -G Ninja
+
+      - name: Build
+        working-directory: tests/net_loopback
+        run: cmake --build build
+
+      - name: Hello smoke (FTXUI link + render)
+        working-directory: tests/net_loopback
+        run: ./build/net_loopback_hello
+
   audio_model_macos:
     name: Audio model (macOS, CoreAudio)
     runs-on: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -353,6 +353,12 @@ lean/build/
 # slang_validate build artifacts
 tests/slang_validate/build/
 
+# net_loopback build (also contains the FetchContent FTXUI checkout)
+tests/net_loopback/build/
+
+# godot_audio_model build
+tests/godot_audio_model/build/
+
 # Scons construction environment dump
 .scons_env.json
 

--- a/tests/net_loopback/CMakeLists.txt
+++ b/tests/net_loopback/CMakeLists.txt
@@ -1,0 +1,55 @@
+# CHI-101 Phase A — net_loopback test binary.
+#
+# Standalone end-to-end voice loopback driven through the audio
+# model. Uses FTXUI v6.1.9 as the terminal UI layer (per the
+# decision doc — replaces the prior Dear ImGui pick from PR #16).
+#
+# Currently scoped to:
+#   * Vendor FTXUI v6.1.9 via FetchContent (no source-tree copy)
+#   * Build a `net_loopback_hello` smoke that constructs an FTXUI
+#     element, dumps its rendered output as a string, and exits
+#     cleanly without grabbing an interactive PTY (CI-friendly)
+#
+# Subsequent sub-passes will:
+#   * Wire SpeechProcessor (sender) + Speech (receiver) into the
+#     loop with a synthetic jitter middleware
+#   * Add observer Components for the slang_validate kernels
+#   * Layer in real picoquic transport from
+#     V-Sekai-fire/multiplayer-fabric-godot/modules/http3 @ 1c3e475
+
+cmake_minimum_required(VERSION 3.20)
+
+include(FetchContent)
+
+# Pin FTXUI to v6.1.9 (released 2025-05-07).
+# https://github.com/ArthurSonzogni/FTXUI/releases/tag/v6.1.9
+FetchContent_Declare(ftxui
+  GIT_REPOSITORY https://github.com/ArthurSonzogni/FTXUI.git
+  GIT_TAG        v6.1.9
+  GIT_SHALLOW    TRUE
+)
+
+# Don't build FTXUI's own examples/tests.
+set(FTXUI_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+set(FTXUI_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(FTXUI_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+set(FTXUI_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(ftxui)
+
+# Smoke test: construct an FTXUI element + render to a string in
+# headless mode. Proves the vendoring works without grabbing a PTY.
+add_executable(net_loopback_hello
+  hello_test.cpp
+)
+
+target_link_libraries(net_loopback_hello
+  PRIVATE
+    ftxui::screen
+    ftxui::dom
+)
+
+target_compile_options(net_loopback_hello
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter
+)

--- a/tests/net_loopback/hello_test.cpp
+++ b/tests/net_loopback/hello_test.cpp
@@ -1,0 +1,46 @@
+// CHI-101 Phase A — FTXUI vendoring smoke.
+//
+// Builds an FTXUI element tree (no Component, no ScreenInteractive),
+// renders it into a Screen, and prints the rendered string. Doesn't
+// open an interactive PTY — CI-friendly.
+//
+// If this builds + runs, FTXUI v6.1.9 is properly vendored via
+// CMake FetchContent and the net_loopback binary can layer richer
+// UI on top in follow-up sub-passes.
+
+#include <ftxui/dom/elements.hpp>
+#include <ftxui/screen/screen.hpp>
+
+#include <cstdio>
+
+int main() {
+	using namespace ftxui;
+
+	// Build a tiny element tree that exercises the three layout
+	// primitives net_loopback will use most: text, hbox, color.
+	auto document = vbox({
+			text("CHI-101 Phase A — net_loopback") | bold,
+			separator(),
+			hbox({
+					text("FTXUI version:") | dim,
+					text(" v6.1.9 (vendored via FetchContent)"),
+			}),
+			hbox({
+					text("Status:") | dim,
+					text(" hello — link works"),
+			}) | color(Color::Green),
+	});
+
+	auto screen = Screen::Create(Dimension::Fit(document));
+	Render(screen, document);
+
+	// `ToString()` emits the final terminal byte stream (with VT100
+	// escapes for color); use Print() for stdout, ToString() for
+	// programmatic capture.
+	const std::string out = screen.ToString();
+	std::printf("%s\n", out.c_str());
+
+	std::printf("net_loopback_hello: PASS — FTXUI v6.1.9 rendered %zu bytes\n",
+			out.size());
+	return 0;
+}


### PR DESCRIPTION
## Summary

First infrastructure pass for the `tests/net_loopback/` test binary recorded in PR #25's decision-doc plan. FTXUI v6.1.9 (the test UI layer that replaced Dear ImGui) is now vendored via CMake FetchContent and proven to build + render under CI on both macOS and Linux.

```
$ ./build/net_loopback_hello
CHI-101 Phase A — net_loopback
─────────────────────────────────────────────────
FTXUI version: v6.1.9 (vendored via FetchContent)
Status: hello — link works
net_loopback_hello: PASS — FTXUI v6.1.9 rendered 351 bytes
```

## What lands

- `tests/net_loopback/CMakeLists.txt` — `FetchContent_Declare ftxui` pinned at v6.1.9; FTXUI's own examples/tests/docs/install disabled
- `tests/net_loopback/hello_test.cpp` — uses `ftxui::text`, `hbox`, `vbox`, `separator`, `bold`, `dim`, `color(Green)`; renders to a `Screen` and dumps the byte stream (no interactive PTY needed)
- `.github/workflows/godot_free_ci.yml` — new `net_loopback (FTXUI vendor, …)` matrix job on `ubuntu-latest` + `macos-latest`
- `.gitignore` — exclude `tests/net_loopback/build/` and `tests/godot_audio_model/build/`

## Headless rendering

The hello smoke uses `Screen::Create(Dimension::Fit(document))` + `Render(...)` + `ToString()` — no `ScreenInteractive`, no PTY allocation. CI runs it unchanged without any `tty:` workaround.

## Next sub-passes

- SpeechProcessor (sender) → Speech (receiver) in-process loopback with synthetic jitter/loss middleware
- Observer Components for the slang_validate kernels (FrameEnergy / FramingCursor / JitterAppend / VadGate) — drive live state into the FTXUI UI
- picoquic transport extracted from V-Sekai-fire/multiplayer-fabric-godot/modules/http3 @ 1c3e475

## Test plan

- [x] `cmake -S . -B build -G Ninja` clean (configure: 5.7s including FTXUI git clone)
- [x] `cmake --build build` clean — 78 targets, FTXUI source + the hello binary
- [x] `./build/net_loopback_hello` PASS
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean