### PR TITLE
CHI-101 Phase A: net_loopback steps 1-3 — driver, dashboard, observer

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -78,13 +78,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install cmake + ninja
+      - name: Install cmake + ninja + opus + libsamplerate
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt-get update
-            sudo apt-get install -y cmake ninja-build
+            sudo apt-get install -y cmake ninja-build libopus-dev libsamplerate0-dev pkg-config
           else
-            brew install cmake ninja
+            brew install cmake ninja opus libsamplerate pkg-config
           fi
         shell: bash
 
@@ -99,6 +99,18 @@ jobs:
       - name: Hello smoke (FTXUI link + render)
         working-directory: tests/net_loopback
         run: ./build/net_loopback_hello
+
+      - name: Loopback driver (sender -> middleware -> receiver)
+        working-directory: tests/net_loopback
+        run: ./build/net_loopback_driver
+
+      - name: Dashboard render smoke (FTXUI layout)
+        working-directory: tests/net_loopback
+        run: ./build/net_loopback_dashboard_smoke
+
+      - name: Observer (live loopback + kernel ⇔ engine markers)
+        working-directory: tests/net_loopback
+        run: ./build/net_loopback_observer
 
   audio_model_macos:
     name: Audio model (macOS, CoreAudio)

--- a/tests/net_loopback/CMakeLists.txt
+++ b/tests/net_loopback/CMakeLists.txt
@@ -18,6 +18,11 @@
 #     V-Sekai-fire/multiplayer-fabric-godot/modules/http3 @ 1c3e475
 
 cmake_minimum_required(VERSION 3.20)
+project(net_loopback CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(FetchContent)
 
@@ -37,6 +42,11 @@ set(FTXUI_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(ftxui)
 
+# Reuse the audio_model speech_engine library so the receive +
+# capture paths are exercised through the unedited godot-speech
+# .cpp files. The audio_model CMake target sits one level up.
+add_subdirectory(../godot_audio_model godot_audio_model_build)
+
 # Smoke test: construct an FTXUI element + render to a string in
 # headless mode. Proves the vendoring works without grabbing a PTY.
 add_executable(net_loopback_hello
@@ -50,6 +60,62 @@ target_link_libraries(net_loopback_hello
 )
 
 target_compile_options(net_loopback_hello
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter
+)
+
+# Step 1: assertion-based loopback driver. Sender (SpeechProcessor)
+# -> NetMiddleware (synthetic jitter/loss/reorder) -> Speech
+# receiver. No UI; pure pass/fail.
+add_executable(net_loopback_driver
+  loopback_test.cpp
+)
+
+target_link_libraries(net_loopback_driver
+  PRIVATE
+    speech_engine
+)
+
+target_compile_options(net_loopback_driver
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter
+)
+
+# Step 2: FTXUI dashboard smoke. Renders the live-state dashboard
+# layout once per profile snapshot. Headless — no ScreenInteractive,
+# no PTY.
+add_executable(net_loopback_dashboard_smoke
+  dashboard_smoke.cpp
+)
+
+target_link_libraries(net_loopback_dashboard_smoke
+  PRIVATE
+    ftxui::screen
+    ftxui::dom
+)
+
+target_compile_options(net_loopback_dashboard_smoke
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter
+)
+
+# Step 3: kernel observer overlay. Drives the live loopback and
+# renders the dashboard with kernel-vs-engine agreement markers
+# flipped to red if anything diverges. Same regression-guard
+# contract as godot_audio_model_agreement, but in the loopback
+# context.
+add_executable(net_loopback_observer
+  observer_test.cpp
+)
+
+target_link_libraries(net_loopback_observer
+  PRIVATE
+    speech_engine
+    ftxui::screen
+    ftxui::dom
+)
+
+target_compile_options(net_loopback_observer
   PRIVATE
     -Wall -Wextra -Wno-unused-parameter
 )

--- a/tests/net_loopback/dashboard.h
+++ b/tests/net_loopback/dashboard.h
@@ -1,0 +1,122 @@
+// CHI-101 Phase A — FTXUI dashboard layout for the loopback test.
+//
+// Pure-function build: takes a snapshot of the engine state and
+// returns an FTXUI `Element` that lays out the live signals as
+// terminal text. Interactive mode (ScreenInteractive + Components)
+// builds Components that wrap this layout; headless mode just
+// renders one frame to a Screen string and exits.
+//
+// Layout sketch:
+//
+//   ┌── CHI-101 net_loopback — profile: lan ────────────────────┐
+//   │ tick: 250 ms                                              │
+//   │                                                           │
+//   │ NET   sent: 20  delivered: 20  dropped: 0  reordered: 0   │
+//   │ JB    size: 20  max:  20    skips: 0                      │
+//   │                                                           │
+//   │ FRAMES per tick:     ████░░░░░░░░░░  4 / 10               │
+//   │ JB    fill:          ████████████░░ 20 / 32               │
+//   │                                                           │
+//   │ kernel ⇔ engine: ✔ FramingCursor agrees  ✔ JitterAppend   │
+//   └───────────────────────────────────────────────────────────┘
+
+#pragma once
+
+#include <ftxui/dom/elements.hpp>
+
+#include <string>
+
+struct DashboardSnapshot {
+	std::string profile_label;
+	double tick_ms = 0.0;
+
+	int net_sent = 0;
+	int net_delivered = 0;
+	int net_dropped = 0;
+	int net_reordered = 0;
+
+	int jb_size = 0;
+	int jb_max = 16;
+	int playback_skips = 0;
+
+	int frames_per_tick = 0;
+	int frames_per_tick_max = 10;
+
+	bool framing_cursor_agrees = true;
+	bool jitter_append_agrees = true;
+};
+
+// Build the dashboard element tree from a snapshot. Pure function;
+// the interactive loop wraps this in a Renderer Component that
+// re-builds it every frame.
+inline ftxui::Element build_dashboard(const DashboardSnapshot &s) {
+	using namespace ftxui;
+
+	auto gauge_row = [](const std::string &label, int cur, int max) {
+		const float ratio = max > 0
+				? static_cast<float>(cur) / static_cast<float>(max)
+				: 0.0f;
+		return hbox({
+				text(label) | size(WIDTH, EQUAL, 26),
+				gauge(ratio) | flex,
+				text("  " + std::to_string(cur) + " / " + std::to_string(max)) | size(WIDTH, EQUAL, 12),
+		});
+	};
+
+	auto kv = [](const std::string &k, const std::string &v) {
+		return hbox({
+				text(k) | dim | size(WIDTH, EQUAL, 12),
+				text(v),
+		});
+	};
+
+	auto agree_marker = [](const std::string &name, bool ok) {
+		return hbox({
+				text(ok ? " ✔ " : " ✘ ") | (ok ? color(Color::Green) : color(Color::Red)),
+				text(name),
+				text(ok ? " agrees" : " DIVERGES") | (ok ? dim : color(Color::Red)),
+		});
+	};
+
+	auto header = hbox({
+			text("CHI-101 net_loopback") | bold,
+			text("  — profile: "),
+			text(s.profile_label) | color(Color::Yellow),
+	});
+
+	auto net_row = hbox({
+			text(" NET ") | color(Color::Cyan) | size(WIDTH, EQUAL, 8),
+			kv("sent:", std::to_string(s.net_sent)) | size(WIDTH, EQUAL, 20),
+			kv("delivered:", std::to_string(s.net_delivered)) | size(WIDTH, EQUAL, 22),
+			kv("dropped:", std::to_string(s.net_dropped)) | size(WIDTH, EQUAL, 18),
+			kv("reordered:", std::to_string(s.net_reordered)),
+	});
+
+	auto jb_row = hbox({
+			text(" JB  ") | color(Color::Cyan) | size(WIDTH, EQUAL, 8),
+			kv("size:", std::to_string(s.jb_size)) | size(WIDTH, EQUAL, 20),
+			kv("max:", std::to_string(s.jb_max)) | size(WIDTH, EQUAL, 22),
+			kv("skips:", std::to_string(s.playback_skips)),
+	});
+
+	auto agreement_row = hbox({
+			text(" KERNEL ⇔ ENGINE: ") | color(Color::Cyan),
+			agree_marker("FramingCursor", s.framing_cursor_agrees),
+			text("  "),
+			agree_marker("JitterAppend", s.jitter_append_agrees),
+	});
+
+	return window(
+			text(" " + s.profile_label + " — tick " + std::to_string(static_cast<int>(s.tick_ms)) + " ms ") | bold,
+			vbox({
+					header,
+					separator(),
+					net_row,
+					jb_row,
+					separator(),
+					gauge_row("FRAMES per tick:", s.frames_per_tick, s.frames_per_tick_max),
+					gauge_row("JB fill:", s.jb_size, s.jb_max),
+					separator(),
+					agreement_row,
+			}));
+}

--- a/tests/net_loopback/dashboard_smoke.cpp
+++ b/tests/net_loopback/dashboard_smoke.cpp
@@ -1,0 +1,97 @@
+// CHI-101 Phase A — net_loopback step 2 smoke.
+//
+// Renders the dashboard layout once with a fabricated snapshot
+// per profile (lan / wan / lossy / geo) and prints each frame.
+// Doesn't run the engine — that's step 3's job (overlay the
+// dashboard on top of a live loopback). This smoke just proves
+// the layout compiles + renders sensible output without grabbing
+// an interactive PTY.
+
+#include "dashboard.h"
+
+#include <ftxui/screen/screen.hpp>
+
+#include <cstdio>
+
+static void render_snapshot(const DashboardSnapshot &s) {
+	using namespace ftxui;
+	auto element = build_dashboard(s);
+	auto screen = Screen::Create(Dimension::Fit(element));
+	Render(screen, element);
+	std::printf("%s\n", screen.ToString().c_str());
+}
+
+int main() {
+	// Mirrors loopback_test.cpp's three profiles plus a GEO satellite
+	// preset from F4's routing table.
+	render_snapshot({
+			.profile_label = "lan (5 ms RTT)",
+			.tick_ms = 250.0,
+			.net_sent = 20,
+			.net_delivered = 20,
+			.net_dropped = 0,
+			.net_reordered = 0,
+			.jb_size = 20,
+			.jb_max = 32,
+			.playback_skips = 0,
+			.frames_per_tick = 10,
+			.frames_per_tick_max = 10,
+			.framing_cursor_agrees = true,
+			.jitter_append_agrees = true,
+	});
+
+	render_snapshot({
+			.profile_label = "wan (80 ms RTT, 8 ms σ)",
+			.tick_ms = 320.0,
+			.net_sent = 20,
+			.net_delivered = 20,
+			.net_dropped = 0,
+			.net_reordered = 3,
+			.jb_size = 18,
+			.jb_max = 32,
+			.playback_skips = 0,
+			.frames_per_tick = 9,
+			.frames_per_tick_max = 10,
+			.framing_cursor_agrees = true,
+			.jitter_append_agrees = true,
+	});
+
+	render_snapshot({
+			.profile_label = "lossy (80 ms RTT, 8 ms σ, 10% loss)",
+			.tick_ms = 320.0,
+			.net_sent = 20,
+			.net_delivered = 17,
+			.net_dropped = 3,
+			.net_reordered = 1,
+			.jb_size = 17,
+			.jb_max = 32,
+			.playback_skips = 0,
+			.frames_per_tick = 8,
+			.frames_per_tick_max = 10,
+			.framing_cursor_agrees = true,
+			.jitter_append_agrees = true,
+	});
+
+	// Stress preset — GEO satellite per F4. Engine would fail
+	// to keep up unless caller raises MAX_JITTER_BUFFER_SIZE to
+	// >= 200 packets; show what the dashboard reports while it's
+	// underprovisioned.
+	render_snapshot({
+			.profile_label = "geo-sat (2000 ms RTT) — UNDER-PROVISIONED jitter",
+			.tick_ms = 2000.0,
+			.net_sent = 200,
+			.net_delivered = 198,
+			.net_dropped = 0,
+			.net_reordered = 12,
+			.jb_size = 32,
+			.jb_max = 32,
+			.playback_skips = 166,
+			.frames_per_tick = 0,
+			.frames_per_tick_max = 10,
+			.framing_cursor_agrees = true,
+			.jitter_append_agrees = true,
+	});
+
+	std::printf("dashboard_smoke: PASS — FTXUI rendered 4 snapshots\n");
+	return 0;
+}

--- a/tests/net_loopback/loopback_test.cpp
+++ b/tests/net_loopback/loopback_test.cpp
@@ -1,0 +1,198 @@
+// CHI-101 Phase A — net_loopback step 1: assertion-based driver.
+//
+// Sender (SpeechProcessor::test_process_mono_audio_frames)
+//   -> speech_processed callback
+//   -> NetMiddleware (synthetic jitter / loss / reorder)
+//   -> Speech::on_received_audio_packet
+//   -> jitter buffer
+//
+// The middleware advances a synthetic clock; the test runs
+// multiple network profiles back-to-back and asserts the engine
+// behaves sensibly under each:
+//
+//   "lan"      — 5 ms latency, 0% loss, no jitter: every packet
+//                delivered, no skips.
+//   "wan"      — 80 ms latency, 8 ms jitter σ, 0% loss:
+//                delivery order may shift but no packets lost.
+//   "lossy"    — 80 ms latency, 8 ms jitter, 10% loss: some
+//                packets drop; jitter buffer fills with valid +
+//                filler entries.
+//
+// Each profile gets its own clean Speech/SpeechProcessor pair.
+
+#include "middleware.h"
+
+#include "../../speech.h"
+#include "../../speech_processor.h"
+#include "audio/audio_stream_generator.h"
+#include "audio/audio_stream_player.h"
+#include "core/core_types.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+struct ProfileResult {
+	int sent = 0;
+	int dropped = 0;
+	int reordered = 0;
+	int delivered = 0;
+	int jitter_buffer_size_end = 0;
+};
+
+static ProfileResult run_profile(const char *label,
+		const NetworkProfile &profile) {
+	std::printf("loopback: profile=%-8s  base=%6.1f ms  σ=%5.1f ms  loss=%.0f%%  reorder=%.0f%%\n",
+			label, profile.base_latency_ms, profile.jitter_sigma_ms,
+			profile.loss_prob * 100.0, profile.reorder_prob * 100.0);
+
+	NetMiddleware net(profile);
+
+	// Receiver side.
+	Speech speech;
+	const int peer_id = 1;
+	AudioStreamPlayer player;
+	player.set_name(String("AudioStreamPlayer"));
+	Ref<AudioStreamGenerator> gen(new AudioStreamGenerator());
+	gen->set_mix_rate(48000.0f);
+	gen->set_buffer_length(1.0f);
+	player.set_stream(gen);
+	speech.add_player_audio(peer_id, &player);
+
+	// Sender side. test_process_mono_audio_frames emits one
+	// speech_processed callback per 10 ms packet — push each one
+	// through the middleware with the synthetic clock at the
+	// packet's nominal capture time.
+	SpeechProcessor processor;
+	double clock_ms = 0.0;
+	const double packet_period_ms = static_cast<double>(SpeechProcessor::SPEECH_SETTING_MILLISECONDS_PER_PACKET);
+	processor.register_speech_processed(
+			[&net, &clock_ms, packet_period_ms](SpeechProcessor::SpeechInput *in) {
+				if (in && in->pcm_byte_array) {
+					net.send(*in->pcm_byte_array, clock_ms);
+					clock_ms += packet_period_ms;
+				}
+			});
+
+	// 200 ms of 440 Hz tone at the voice rate.
+	const uint32_t voice_rate = SpeechProcessor::SPEECH_SETTING_VOICE_SAMPLE_RATE;
+	const int frames = static_cast<int>(voice_rate / 5); // 200 ms
+	PackedFloat32Array mono;
+	mono.resize(frames);
+	for (int i = 0; i < frames; ++i) {
+		const double t = static_cast<double>(i) / static_cast<double>(voice_rate);
+		mono.write[i] = static_cast<float>(std::sin(2.0 * 3.14159265358979 * 440.0 * t) * 0.5);
+	}
+	processor.test_process_mono_audio_frames(mono, voice_rate);
+
+	// Drain the middleware. Advance the synthetic clock past the
+	// last sent packet + max expected delay so every queued
+	// packet hits the receiver.
+	const double drain_until = clock_ms + profile.base_latency_ms + 5.0 * profile.jitter_sigma_ms + 10.0;
+	auto inflight = net.drain(drain_until);
+	for (size_t i = 0; i < inflight.size(); ++i) {
+		speech.on_received_audio_packet(peer_id, inflight[i].sequence_id,
+				inflight[i].packet);
+	}
+
+	// Inspect end state.
+	Dictionary elem = speech.get_player_audio()[peer_id];
+	Array jb = elem["jitter_buffer"];
+
+	ProfileResult r;
+	r.sent = net.sent;
+	r.dropped = net.dropped;
+	r.reordered = net.reordered;
+	r.delivered = net.delivered;
+	r.jitter_buffer_size_end = jb.size();
+
+	std::printf("  sent=%-3d delivered=%-3d dropped=%-3d reordered=%-3d  jb_size=%d\n",
+			r.sent, r.delivered, r.dropped, r.reordered,
+			r.jitter_buffer_size_end);
+	return r;
+}
+
+int main() {
+	int fails = 0;
+
+	// LAN: deterministic delivery, every packet arrives, no drops.
+	{
+		NetworkProfile p;
+		p.base_latency_ms = 5.0;
+		p.seed = 0x1ABC0DE'001u;
+		auto r = run_profile("lan", p);
+		if (r.delivered != r.sent || r.dropped != 0) {
+			std::fprintf(stderr,
+					"FAIL: lan profile lost packets (sent=%d, delivered=%d, dropped=%d)\n",
+					r.sent, r.delivered, r.dropped);
+			++fails;
+		}
+		if (r.jitter_buffer_size_end <= 0) {
+			std::fprintf(stderr,
+					"FAIL: lan profile left jitter buffer empty (sent %d packets)\n",
+					r.sent);
+			++fails;
+		}
+	}
+
+	// WAN: jitter shouldn't drop anything, just rearrange arrival.
+	{
+		NetworkProfile p;
+		p.base_latency_ms = 80.0;
+		p.jitter_sigma_ms = 8.0;
+		p.reorder_window = 3;
+		p.reorder_prob = 0.15;
+		p.seed = 0x2EA15E'002u;
+		auto r = run_profile("wan", p);
+		if (r.delivered != r.sent || r.dropped != 0) {
+			std::fprintf(stderr,
+					"FAIL: wan profile lost packets (sent=%d, delivered=%d, dropped=%d)\n",
+					r.sent, r.delivered, r.dropped);
+			++fails;
+		}
+		if (r.reordered == 0) {
+			std::fprintf(stderr,
+					"FAIL: wan profile saw zero reorders with reorder_prob=15%% over %d packets\n",
+					r.sent);
+			++fails;
+		}
+	}
+
+	// Lossy: ~10% drop rate; engine must absorb it via filler
+	// packets and not crash.
+	{
+		NetworkProfile p;
+		p.base_latency_ms = 80.0;
+		p.jitter_sigma_ms = 8.0;
+		p.loss_prob = 0.10;
+		p.reorder_window = 3;
+		p.reorder_prob = 0.10;
+		p.seed = 0x3105500'003u;
+		auto r = run_profile("lossy", p);
+		if (r.dropped == 0) {
+			std::fprintf(stderr,
+					"FAIL: lossy profile dropped zero packets at 10%% loss over %d sent\n",
+					r.sent);
+			++fails;
+		}
+		if (r.delivered + r.dropped != r.sent) {
+			std::fprintf(stderr,
+					"FAIL: lossy profile bookkeeping: sent=%d, delivered=%d, dropped=%d\n",
+					r.sent, r.delivered, r.dropped);
+			++fails;
+		}
+		if (r.jitter_buffer_size_end <= 0) {
+			std::fprintf(stderr,
+					"FAIL: lossy profile left jitter buffer empty\n");
+			++fails;
+		}
+	}
+
+	if (fails == 0) {
+		std::printf("loopback: PASS — all three profiles delivered the expected sender->receiver behaviour\n");
+		return 0;
+	}
+	std::fprintf(stderr, "loopback: %d FAIL\n", fails);
+	return 1;
+}

--- a/tests/net_loopback/middleware.h
+++ b/tests/net_loopback/middleware.h
@@ -1,0 +1,126 @@
+// CHI-101 Phase A — synthetic network middleware for the loopback
+// driver. Sits between SpeechProcessor's `speech_processed`
+// callback (the sender) and Speech::on_received_audio_packet
+// (the receiver), applying configurable jitter / loss / reorder
+// before delivering each packet.
+//
+// Headless and deterministic — every behavior is driven from a
+// seeded `std::mt19937` so the same NetworkProfile produces the
+// same sequence of delays / drops / swaps across runs.
+//
+// Tick semantics: the test driver increments a synthetic clock
+// (`tick_ms`) before each delivery cycle. The middleware queues
+// packets with a `deliver_at_ms = now + delay`. `drain(now)`
+// returns every packet whose deliver_at_ms <= now, in arrival
+// order (the reorder window jumbles arrival before queue, not
+// delivery — matches how a real network reorders out-of-flight
+// datagrams).
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <random>
+#include <vector>
+
+#include "core/core_types.h"
+
+struct NetworkProfile {
+	// Static one-way latency in ms — every packet waits at least
+	// this long before delivery.
+	double base_latency_ms = 0.0;
+	// Per-packet jitter σ in ms — added on top of base_latency_ms,
+	// drawn from a half-normal distribution (always >= 0).
+	double jitter_sigma_ms = 0.0;
+	// Drop probability ∈ [0, 1].
+	double loss_prob = 0.0;
+	// Reorder window: each packet may be swapped with one within
+	// the next `reorder_window` ingress positions with probability
+	// `reorder_prob`. Matches typical out-of-order reordering on
+	// a congested WAN path.
+	int reorder_window = 0;
+	double reorder_prob = 0.0;
+	// RNG seed for deterministic replays. Same profile + same
+	// seed = same sequence of delivery decisions.
+	uint64_t seed = 0xC011'101'F1u;
+};
+
+struct NetMiddleware {
+	struct InFlight {
+		PackedByteArray packet;
+		int sequence_id = 0; // sender's view of order; preserved across drop/reorder
+		double deliver_at_ms = 0.0;
+	};
+
+	NetworkProfile profile;
+	std::mt19937_64 rng;
+	std::deque<InFlight> queue;
+	int next_sequence = 1;
+
+	// Counters — accumulate across the whole run.
+	int sent = 0;
+	int dropped = 0;
+	int reordered = 0;
+	int delivered = 0;
+
+	explicit NetMiddleware(NetworkProfile p) :
+			profile(p), rng(p.seed) {}
+
+	// Submit a packet from the sender side at `now_ms`. Returns
+	// false if the packet was dropped; otherwise the packet is
+	// queued for later `drain`.
+	bool send(const PackedByteArray &packet, double now_ms) {
+		++sent;
+		if (profile.loss_prob > 0.0) {
+			std::uniform_real_distribution<double> u(0.0, 1.0);
+			if (u(rng) < profile.loss_prob) {
+				++dropped;
+				return false;
+			}
+		}
+
+		double delay = profile.base_latency_ms;
+		if (profile.jitter_sigma_ms > 0.0) {
+			std::normal_distribution<double> n(0.0, profile.jitter_sigma_ms);
+			delay += std::abs(n(rng));
+		}
+
+		InFlight inflight;
+		inflight.packet = packet;
+		inflight.sequence_id = next_sequence++;
+		inflight.deliver_at_ms = now_ms + delay;
+		queue.push_back(inflight);
+
+		// Reorder: occasionally swap the just-enqueued packet
+		// with one earlier in the queue (within reorder_window).
+		if (profile.reorder_window > 0 && profile.reorder_prob > 0.0 && queue.size() >= 2) {
+			std::uniform_real_distribution<double> u(0.0, 1.0);
+			if (u(rng) < profile.reorder_prob) {
+				const int window = std::min<int>(
+						static_cast<int>(queue.size()) - 1,
+						profile.reorder_window);
+				if (window > 0) {
+					std::uniform_int_distribution<int> dpos(1, window);
+					const int back_off = dpos(rng);
+					const auto last = queue.end() - 1;
+					std::iter_swap(last, last - back_off);
+					++reordered;
+				}
+			}
+		}
+		return true;
+	}
+
+	// Pop every packet whose deliver_at_ms <= now_ms, in queue
+	// order. The caller hands each to the receiver.
+	std::vector<InFlight> drain(double now_ms) {
+		std::vector<InFlight> out;
+		while (!queue.empty() && queue.front().deliver_at_ms <= now_ms) {
+			out.push_back(queue.front());
+			queue.pop_front();
+			++delivered;
+		}
+		return out;
+	}
+};

--- a/tests/net_loopback/observer_test.cpp
+++ b/tests/net_loopback/observer_test.cpp
@@ -1,0 +1,181 @@
+// CHI-101 Phase A — net_loopback step 3: live loopback + dashboard
+// observer + slang_validate kernel agreement.
+//
+// Drives the same three NetMiddleware profiles as the assertion-
+// based driver (step 1), captures per-profile snapshots of the
+// engine state, runs the FramingCursor + JitterAppend kernels'
+// formulas alongside the engine, and renders the dashboard for
+// each profile to stdout via FTXUI.
+//
+// The agreement check is the high-leverage part: if the kernel
+// formulas predict a different value than the engine reports,
+// the dashboard's "KERNEL ⇔ ENGINE" row flips to red and the
+// test fails. Same regression-guard contract as the
+// godot_audio_model_agreement binary, but now wrapped in the
+// network-loopback context where future tests will live.
+
+#include "dashboard.h"
+#include "middleware.h"
+
+#include "../../speech.h"
+#include "../../speech_processor.h"
+#include "audio/audio_stream_generator.h"
+#include "audio/audio_stream_player.h"
+#include "core/core_types.h"
+
+#include <ftxui/screen/screen.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+struct RunResult {
+	DashboardSnapshot snapshot;
+	bool engine_packet_count_matches_kernel = true;
+	bool engine_jb_size_matches_kernel = true;
+};
+
+static RunResult run_profile(const char *label,
+		const NetworkProfile &profile) {
+	NetMiddleware net(profile);
+
+	Speech speech;
+	const int peer_id = 1;
+	AudioStreamPlayer player;
+	player.set_name(String("AudioStreamPlayer"));
+	Ref<AudioStreamGenerator> gen(new AudioStreamGenerator());
+	gen->set_mix_rate(48000.0f);
+	gen->set_buffer_length(1.0f);
+	player.set_stream(gen);
+	speech.add_player_audio(peer_id, &player);
+
+	SpeechProcessor processor;
+	double clock_ms = 0.0;
+	const double packet_period_ms = static_cast<double>(SpeechProcessor::SPEECH_SETTING_MILLISECONDS_PER_PACKET);
+	processor.register_speech_processed(
+			[&net, &clock_ms, packet_period_ms](SpeechProcessor::SpeechInput *in) {
+				if (in && in->pcm_byte_array) {
+					net.send(*in->pcm_byte_array, clock_ms);
+					clock_ms += packet_period_ms;
+				}
+			});
+
+	// 200 ms of 440 Hz tone at the voice rate.
+	const uint32_t voice_rate = SpeechProcessor::SPEECH_SETTING_VOICE_SAMPLE_RATE;
+	const int frames = static_cast<int>(voice_rate / 5);
+	PackedFloat32Array mono;
+	mono.resize(frames);
+	for (int i = 0; i < frames; ++i) {
+		const double t = static_cast<double>(i) / static_cast<double>(voice_rate);
+		mono.write[i] = static_cast<float>(std::sin(2.0 * 3.14159265358979 * 440.0 * t) * 0.5);
+	}
+	processor.test_process_mono_audio_frames(mono, voice_rate);
+
+	// Drain the middleware.
+	const double drain_until = clock_ms + profile.base_latency_ms + 5.0 * profile.jitter_sigma_ms + 10.0;
+	auto inflight = net.drain(drain_until);
+	for (size_t i = 0; i < inflight.size(); ++i) {
+		speech.on_received_audio_packet(peer_id, inflight[i].sequence_id,
+				inflight[i].packet);
+	}
+
+	Dictionary elem = speech.get_player_audio()[peer_id];
+	Array jb = elem["jitter_buffer"];
+
+	// === Kernel-vs-engine agreement, observer style ===========
+	// FramingCursor predicts how many packets test_process emits
+	// from `frames` mono samples at the voice rate (no resample):
+	//   expected_packets = frames / SPEECH_SETTING_BUFFER_FRAME_COUNT
+	const int kernel_expected_sent =
+			frames / SpeechProcessor::SPEECH_SETTING_BUFFER_FRAME_COUNT;
+	const bool framing_agrees = (net.sent == kernel_expected_sent);
+
+	// JitterAppend predicts: the jitter buffer grows by 1 per
+	// in-order packet, capped at MAX_JITTER_BUFFER_SIZE. With
+	// drops, fewer "filler" entries are needed (engine drops them
+	// on receive). The exact size depends on the seed-dependent
+	// reorder + drop sequence, but the kernel-style bound is:
+	//   jb_size <= min(delivered + dropped, MAX_JITTER_BUFFER_SIZE)
+	const int max_jb = speech.get_max_jitter_buffer_size();
+	const int kernel_jb_upper = (net.sent < max_jb) ? net.sent : max_jb;
+	const bool jb_agrees = (jb.size() <= kernel_jb_upper);
+
+	RunResult r;
+	r.snapshot.profile_label = label;
+	r.snapshot.tick_ms = drain_until;
+	r.snapshot.net_sent = net.sent;
+	r.snapshot.net_delivered = net.delivered;
+	r.snapshot.net_dropped = net.dropped;
+	r.snapshot.net_reordered = net.reordered;
+	r.snapshot.jb_size = jb.size();
+	r.snapshot.jb_max = max_jb;
+	r.snapshot.playback_skips = 0;
+	r.snapshot.frames_per_tick = net.delivered;
+	r.snapshot.frames_per_tick_max = kernel_expected_sent;
+	r.snapshot.framing_cursor_agrees = framing_agrees;
+	r.snapshot.jitter_append_agrees = jb_agrees;
+	r.engine_packet_count_matches_kernel = framing_agrees;
+	r.engine_jb_size_matches_kernel = jb_agrees;
+	return r;
+}
+
+static void render(const DashboardSnapshot &s) {
+	auto element = build_dashboard(s);
+	auto screen = ftxui::Screen::Create(ftxui::Dimension::Fit(element));
+	ftxui::Render(screen, element);
+	std::printf("%s\n", screen.ToString().c_str());
+}
+
+int main() {
+	int fails = 0;
+
+	{
+		NetworkProfile p;
+		p.base_latency_ms = 5.0;
+		p.seed = 0x1ABC0DE'001u;
+		auto r = run_profile("lan (5 ms RTT)", p);
+		render(r.snapshot);
+		if (!r.engine_packet_count_matches_kernel || !r.engine_jb_size_matches_kernel) {
+			std::fprintf(stderr, "FAIL: lan kernel ⇔ engine disagreement\n");
+			++fails;
+		}
+	}
+
+	{
+		NetworkProfile p;
+		p.base_latency_ms = 80.0;
+		p.jitter_sigma_ms = 8.0;
+		p.reorder_window = 3;
+		p.reorder_prob = 0.15;
+		p.seed = 0x2EA15E'002u;
+		auto r = run_profile("wan (80 ms RTT, 8 ms σ)", p);
+		render(r.snapshot);
+		if (!r.engine_packet_count_matches_kernel || !r.engine_jb_size_matches_kernel) {
+			std::fprintf(stderr, "FAIL: wan kernel ⇔ engine disagreement\n");
+			++fails;
+		}
+	}
+
+	{
+		NetworkProfile p;
+		p.base_latency_ms = 80.0;
+		p.jitter_sigma_ms = 8.0;
+		p.loss_prob = 0.10;
+		p.reorder_window = 3;
+		p.reorder_prob = 0.10;
+		p.seed = 0x3105500'003u;
+		auto r = run_profile("lossy (80 ms RTT, 8 ms σ, 10% loss)", p);
+		render(r.snapshot);
+		if (!r.engine_packet_count_matches_kernel || !r.engine_jb_size_matches_kernel) {
+			std::fprintf(stderr, "FAIL: lossy kernel ⇔ engine disagreement\n");
+			++fails;
+		}
+	}
+
+	if (fails == 0) {
+		std::printf("observer: PASS — kernel ⇔ engine agreement holds across all profiles\n");
+		return 0;
+	}
+	std::fprintf(stderr, "observer: %d FAIL\n", fails);
+	return 1;
+}


### PR DESCRIPTION
## Summary

Three of the four sub-passes laid out for the FTXUI-driven `net_loopback` test binary. All three exercise the **real godot-speech engine code** running against the audio model.

## Step 1 — assertion-based driver

Sender (`SpeechProcessor::test_process_mono_audio_frames`) → `NetMiddleware` (seeded synthetic jitter / loss / reorder) → `Speech::on_received_audio_packet` → jitter buffer. Three profiles run back-to-back:

```
loopback: profile=lan       base=   5.0 ms  σ=  0.0 ms  loss=0%  reorder=0%
  sent=20  delivered=20  dropped=0   reordered=0    jb_size=20
loopback: profile=wan       base=  80.0 ms  σ=  8.0 ms  loss=0%  reorder=15%
  sent=20  delivered=20  dropped=0   reordered=3    jb_size=18
loopback: profile=lossy     base=  80.0 ms  σ=  8.0 ms  loss=10%  reorder=10%
  sent=20  delivered=17  dropped=3   reordered=1    jb_size=17
loopback: PASS — all three profiles delivered the expected sender->receiver behaviour
```

`std::normal_distribution` for jitter σ, `std::uniform_real_distribution` for drops, sliding-window swap for reorders. Deterministic per `NetworkProfile::seed`.

## Step 2 — FTXUI dashboard layout

Pure-function `build_dashboard(snapshot) -> Element` returning an FTXUI `window()` with:
- profile header (yellow)
- NET row (cyan: sent / delivered / dropped / reordered)
- JB row (cyan: size / max / skips)
- gauges for FRAMES per tick + JB fill
- KERNEL ⇔ ENGINE agreement markers (green ✔ / red ✘)

Headless render via `Screen::Create` + `Render` + `ToString()` — no PTY required, CI runs the smoke as-is.

## Step 3 — observer with kernel ⇔ engine markers

Drives the same three profiles as step 1, renders the dashboard for each with live agreement check:

- FramingCursor: `kernel_expected_sent = frames / SPEECH_SETTING_BUFFER_FRAME_COUNT` vs the observed `net.sent`
- JitterAppend: `kernel_jb_upper = min(net.sent, MAX_JITTER_BUFFER_SIZE)` vs observed `jb.size()`

Both held green across all three profiles. The dashboard's agreement row flips to red on any divergence — same regression-guard contract as `godot_audio_model_agreement`, but in the loopback context.

## CI

Adds four new steps to the existing `net_loopback (FTXUI vendor, …)` matrix job:

- `Hello smoke (FTXUI link + render)`
- `Loopback driver (sender -> middleware -> receiver)`
- `Dashboard render smoke (FTXUI layout)`
- `Observer (live loopback + kernel ⇔ engine markers)`

opus + libsamplerate install moved up to the top of the job (was inside the original `audio_model_*` jobs only — `net_loopback` now `add_subdirectory`s the audio model and needs the libs at configure time).

## Out of scope — step 4

Step 4 is **picoquic transport**: vendor picoquic from V-Sekai-fire/multiplayer-fabric-godot/modules/http3 @ 1c3e475, build via CMake, replace the in-process `NetMiddleware` with a real QUIC datagram hop. Substantial standalone work; lands in a follow-up PR.

## Test plan

- [x] `cmake --build build` clean on macOS
- [x] All four net_loopback binaries pass locally (hello / driver / dashboard / observer)
- [x] All six godot_audio_model binaries still pass via `add_subdirectory`
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean