### PR TITLE
CHI-101 Phase A: net_loopback step 4 — picoquic vendoring smoke

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -78,13 +78,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install cmake + ninja + opus + libsamplerate
+      - name: Install cmake + ninja + opus + libsamplerate + openssl
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             sudo apt-get update
-            sudo apt-get install -y cmake ninja-build libopus-dev libsamplerate0-dev pkg-config
+            sudo apt-get install -y cmake ninja-build libopus-dev libsamplerate0-dev libssl-dev pkg-config
           else
-            brew install cmake ninja opus libsamplerate pkg-config
+            brew install cmake ninja opus libsamplerate openssl@3 pkg-config
           fi
         shell: bash
 
@@ -111,6 +111,10 @@ jobs:
       - name: Observer (live loopback + kernel ⇔ engine markers)
         working-directory: tests/net_loopback
         run: ./build/net_loopback_observer
+
+      - name: picoquic vendoring smoke
+        working-directory: tests/net_loopback
+        run: ./build/net_loopback_picoquic_smoke
 
   audio_model_macos:
     name: Audio model (macOS, CoreAudio)

--- a/tests/net_loopback/CMakeLists.txt
+++ b/tests/net_loopback/CMakeLists.txt
@@ -42,6 +42,19 @@ set(FTXUI_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
 
 FetchContent_MakeAvailable(ftxui)
 
+# Picoquic — vendor via FetchContent. picoquic's master branch is
+# what people use (last tag is "draft-16-final" from QUIC pre-RFC).
+# Pin a known-good master commit. The picotls TLS backend is auto-
+# fetched via PICOQUIC_FETCH_PTLS; the picotls-openssl layer needs
+# system OpenSSL (libssl-dev on Linux, openssl@3 from brew on macOS).
+set(PICOQUIC_FETCH_PTLS ON CACHE BOOL "" FORCE)
+FetchContent_Declare(picoquic
+  GIT_REPOSITORY https://github.com/private-octopus/picoquic.git
+  GIT_TAG        f54239a39145
+  GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(picoquic)
+
 # Reuse the audio_model speech_engine library so the receive +
 # capture paths are exercised through the unedited godot-speech
 # .cpp files. The audio_model CMake target sits one level up.
@@ -116,6 +129,25 @@ target_link_libraries(net_loopback_observer
 )
 
 target_compile_options(net_loopback_observer
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter
+)
+
+# Step 4: picoquic vendoring smoke. Constructs a picoquic_quic_t
+# context, queries the library version, and frees it. Doesn't open
+# sockets — proves the FetchContent vendoring + header path + link
+# work. Real QUIC datagram loopback (4b) wires it through the
+# NetMiddleware abstraction in a follow-up.
+add_executable(net_loopback_picoquic_smoke
+  picoquic_smoke.cpp
+)
+
+target_link_libraries(net_loopback_picoquic_smoke
+  PRIVATE
+    picoquic-core
+)
+
+target_compile_options(net_loopback_picoquic_smoke
   PRIVATE
     -Wall -Wextra -Wno-unused-parameter
 )

--- a/tests/net_loopback/picoquic_smoke.cpp
+++ b/tests/net_loopback/picoquic_smoke.cpp
@@ -1,0 +1,52 @@
+// CHI-101 Phase A — net_loopback step 4 smoke (picoquic vendoring).
+//
+// Constructs a picoquic_quic_t context with a no-op stream callback,
+// reports the library version, and frees the context. Doesn't open
+// sockets, doesn't negotiate TLS — proves the FetchContent vendoring
+// + header path + link work end-to-end.
+//
+// Real QUIC datagram loopback (a follow-up sub-pass) will:
+//   * spin up two picoquic_quic_t contexts on localhost UDP ports
+//   * connect them with a QUIC datagram-only application
+//   * route NetMiddleware send() calls through `picoquic_queue_datagram_frame`
+//   * route received datagrams into Speech::on_received_audio_packet
+
+#include "picoquic.h"
+
+#include <cstdio>
+
+int main() {
+	std::printf("picoquic_smoke: picoquic version = %s\n", PICOQUIC_VERSION);
+
+	// Construct a minimal quic context — server-side with the
+	// default settings; no certificates loaded; no stream callback
+	// fires because we never accept a connection. Just exercises
+	// the alloc + free paths.
+	const uint64_t current_time = 0;
+	picoquic_quic_t *quic = picoquic_create(
+			/*nb_connections=*/8,
+			/*cert_file_name=*/nullptr,
+			/*key_file_name=*/nullptr,
+			/*cert_root_file_name=*/nullptr,
+			/*alpn=*/nullptr,
+			/*default_callback_fn=*/nullptr,
+			/*default_callback_ctx=*/nullptr,
+			/*cnx_id_callback_fn=*/nullptr,
+			/*cnx_id_callback_ctx=*/nullptr,
+			/*reset_seed=*/nullptr,
+			current_time,
+			/*p_simulated_time=*/nullptr,
+			/*ticket_file_name=*/nullptr,
+			/*ticket_encryption_key=*/nullptr,
+			/*ticket_encryption_key_length=*/0);
+
+	if (!quic) {
+		std::fprintf(stderr, "FAIL: picoquic_create returned null\n");
+		return 1;
+	}
+	std::printf("picoquic_smoke: picoquic_quic_t allocated\n");
+
+	picoquic_free(quic);
+	std::printf("picoquic_smoke: PASS — picoquic linked + alloc/free round-trip\n");
+	return 0;
+}


### PR DESCRIPTION
## Summary

Step 4 of the net_loopback plan: vendor [picoquic](https://github.com/private-octopus/picoquic) (the QUIC implementation used by V-Sekai-fire's multiplayer-fabric http3 module) via CMake FetchContent and prove the build integration works.

```
$ ./build/net_loopback_picoquic_smoke
picoquic_smoke: picoquic version = 1.1.48.0
picoquic_smoke: picoquic_quic_t allocated
picoquic_smoke: PASS — picoquic linked + alloc/free round-trip
```

## What lands

- `tests/net_loopback/CMakeLists.txt` — `FetchContent_Declare(picoquic GIT_TAG f54239a39145)` (master HEAD as of 2026-05-04); `PICOQUIC_FETCH_PTLS=ON` auto-fetches the picotls TLS layer
- `tests/net_loopback/picoquic_smoke.cpp` — constructs a `picoquic_quic_t` context with no callbacks, no certs, no sockets; verifies version + alloc/free
- CI adds `libssl-dev` (Linux) / `openssl@3` (macOS) to the install step, plus the new `picoquic vendoring smoke` step on both runners

## Why pin a commit instead of a tag

picoquic's last tag is `draft-16-final` from QUIC pre-RFC days. Their `master` branch is what consumers use; the commit pin gives reproducibility.

## Build time impact

Vendoring picoquic adds ~50K LOC of C (picoquic + picotls + the picotls tests it can't fully disable). Local clean rebuild ~70 seconds. CI job time on macos-latest ~3.5 min, ubuntu-latest ~2.5 min. Acceptable for the regression value — the hard part (cross-platform FetchContent + picotls + OpenSSL linkage) is done.

## Doesn't yet wire QUIC through NetMiddleware

Substantial follow-up: spin up two `picoquic_quic_t` contexts on localhost UDP ports, negotiate a connection with a custom ALPN, route NetMiddleware `send()` calls through `picoquic_queue_datagram_frame`, route received datagrams into `Speech::on_received_audio_packet`. The vendoring milestone proves the rest is reachable.

## Test plan

- [x] `cmake --build build` clean on macOS — 80 targets including picoquic + picotls + ftxui + audio_model + speech_engine
- [x] `./build/net_loopback_picoquic_smoke` PASS
- [x] All four prior net_loopback binaries still pass (hello / driver / dashboard / observer)
- [x] All six audio_model binaries still pass via the `add_subdirectory` chain
- [x] `clang_format.sh` clean
- [x] `file_format.sh` clean