### PR TITLE
CHI-101 Phase A: net_loopback step 4c — picoquic datagram stress sweep

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -120,6 +120,10 @@ jobs:
         working-directory: tests/net_loopback
         run: ./build/net_loopback_picoquic_datagram
 
+      - name: picoquic datagram stress sweep
+        working-directory: tests/net_loopback
+        run: ./build/net_loopback_picoquic_stress
+
   audio_model_macos:
     name: Audio model (macOS, CoreAudio)
     runs-on: macos-latest

--- a/tests/net_loopback/CMakeLists.txt
+++ b/tests/net_loopback/CMakeLists.txt
@@ -185,3 +185,29 @@ target_compile_options(net_loopback_picoquic_datagram
   PRIVATE
     -Wall -Wextra -Wno-unused-parameter
 )
+
+# Step 4c: picoquic datagram stress sweep. Reuses the shared
+# `picoquic_loopback_core.h` harness to drive several (count, size)
+# configurations and assert byte-exact round-trip for each. Same
+# transport setup as 4b — server in background thread, client on
+# main thread, max_datagram_frame_size negotiated.
+add_executable(net_loopback_picoquic_stress
+  picoquic_stress_test.cpp
+)
+
+target_link_libraries(net_loopback_picoquic_stress
+  PRIVATE
+    picoquic-core
+    picoquic-log
+)
+
+target_compile_definitions(net_loopback_picoquic_stress
+  PRIVATE
+    PICOQUIC_LOOPBACK_CERT_PATH="${picoquic_SOURCE_DIR}/certs/cert.pem"
+    PICOQUIC_LOOPBACK_KEY_PATH="${picoquic_SOURCE_DIR}/certs/key.pem"
+)
+
+target_compile_options(net_loopback_picoquic_stress
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter
+)

--- a/tests/net_loopback/picoquic_loopback_core.h
+++ b/tests/net_loopback/picoquic_loopback_core.h
@@ -1,0 +1,477 @@
+// CHI-101 Phase A — shared loopback harness for the real-QUIC tests.
+//
+// Both `picoquic_loopback_test.cpp` (small sanity check) and
+// `picoquic_stress_test.cpp` (count + payload sweep) call
+// `run_picoquic_loopback(cfg)` with different (count, size) configs
+// and let it stand up the same client / server / packet-loop dance.
+//
+// Returns a `LoopbackResult` with the counts the test driver
+// asserts on: queued + acked from the client's side, and the bytes
+// the server saw via picoquic_callback_datagram. The result also
+// records the wall-clock duration so the stress driver can print
+// throughput numbers.
+
+#pragma once
+
+#include <picoquic.h>
+#include <picoquic_packet_loop.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#ifndef PICOQUIC_LOOPBACK_CERT_PATH
+#error "PICOQUIC_LOOPBACK_CERT_PATH must be defined by the build"
+#endif
+#ifndef PICOQUIC_LOOPBACK_KEY_PATH
+#error "PICOQUIC_LOOPBACK_KEY_PATH must be defined by the build"
+#endif
+
+namespace picoquic_loopback {
+constexpr const char *kAlpn = "voice-loopback";
+constexpr const char *kSni = "test.example.com";
+constexpr uint32_t kMaxDatagramFrameSize = 1500;
+constexpr uint64_t kCloseGraceUs = 200'000;
+
+struct LoopbackConfig {
+	int datagram_count = 32;
+	size_t datagram_size = 64;
+	// How long to wait for the round-trip to complete before declaring
+	// the test stuck. 0 = derive from datagram_count.
+	uint64_t test_timeout_ms = 0;
+	// Maximum unacked datagrams in flight at any moment. New ones are
+	// queued on every datagram_acked. Keeps the send + recv socket
+	// buffers from overflowing on bursty configs. 2 is a safe choice
+	// for sustained throughput; 8 is good for low-count bursts.
+	int in_flight_window = 2;
+	// UDP socket SO_RCVBUF / SO_SNDBUF in bytes. 0 = picoquic default
+	// (~64 KB). 2 MB safely covers all sweep configurations.
+	int socket_buffer_size = 2 * 1024 * 1024;
+};
+
+struct LoopbackResult {
+	int datagrams_queued = 0;
+	int datagrams_acked = 0;
+	int datagrams_received = 0;
+	int server_connections_seen = 0;
+	int payload_mismatches = 0;
+	int missing_sequences = 0;
+	double elapsed_ms = 0.0;
+	bool timed_out = false;
+};
+
+struct ServerCtx {
+	std::mutex mu;
+	std::vector<std::vector<uint8_t>> received;
+	std::atomic<int> connections_seen{ 0 };
+};
+
+struct ClientCtx {
+	picoquic_cnx_t *cnx = nullptr;
+	int datagrams_queued = 0;
+	int datagrams_acked = 0;
+	int datagrams_lost = 0; // picoquic gave up on these
+	int last_progress_count = 0; // acked + lost from last progress tick
+	int target_count = 0;
+	size_t target_size = 0;
+	int in_flight_window = 8;
+	uint64_t all_queued_at_us = 0;
+	uint64_t last_progress_us = 0;
+	uint64_t done_marked_us = 0;
+	uint64_t stall_grace_us = 2'000'000; // 2 s with no ack/lost progress → close
+	bool close_called = false;
+};
+
+inline void fill_payload(uint8_t *buf, size_t len, int seq) {
+	std::memset(buf, 0, len);
+	buf[0] = static_cast<uint8_t>(seq & 0xff);
+	buf[1] = static_cast<uint8_t>((seq >> 8) & 0xff);
+	buf[2] = static_cast<uint8_t>((seq >> 16) & 0xff);
+	buf[3] = static_cast<uint8_t>((seq >> 24) & 0xff);
+	for (size_t b = 4; b < len; ++b) {
+		buf[b] = static_cast<uint8_t>((seq + b) & 0xff);
+	}
+}
+
+// Top up the in-flight window: queue datagrams until either the
+// target count is reached or the window (queued - resolved) is full.
+inline int refill_in_flight(ClientCtx *ctx) {
+	std::vector<uint8_t> payload(ctx->target_size);
+	while (ctx->datagrams_queued < ctx->target_count) {
+		const int resolved = ctx->datagrams_acked + ctx->datagrams_lost;
+		const int in_flight = ctx->datagrams_queued - resolved;
+		if (in_flight >= ctx->in_flight_window) {
+			break;
+		}
+		const int seq = ctx->datagrams_queued;
+		fill_payload(payload.data(), payload.size(), seq);
+		int rc = picoquic_queue_datagram_frame(ctx->cnx, payload.size(), payload.data());
+		if (rc != 0) {
+			std::fprintf(stderr, "picoquic_queue_datagram_frame[%d] = %d\n", seq, rc);
+			return rc;
+		}
+		ctx->datagrams_queued++;
+	}
+	return 0;
+}
+
+inline int server_callback(picoquic_cnx_t *cnx,
+		uint64_t /*stream_id*/, uint8_t *bytes, size_t length,
+		picoquic_call_back_event_t event, void *callback_ctx, void * /*v_stream_ctx*/) {
+	auto *ctx = static_cast<ServerCtx *>(callback_ctx);
+	if (ctx == nullptr) {
+		return 0;
+	}
+	switch (event) {
+		case picoquic_callback_almost_ready:
+		case picoquic_callback_ready:
+			ctx->connections_seen.fetch_add(1, std::memory_order_release);
+			break;
+		case picoquic_callback_datagram: {
+			std::lock_guard<std::mutex> lock(ctx->mu);
+			ctx->received.emplace_back(bytes, bytes + length);
+		} break;
+		case picoquic_callback_close:
+		case picoquic_callback_application_close:
+		case picoquic_callback_stateless_reset:
+			picoquic_set_callback(cnx, nullptr, nullptr);
+			break;
+		default:
+			break;
+	}
+	return 0;
+}
+
+inline int client_callback(picoquic_cnx_t *cnx,
+		uint64_t /*stream_id*/, uint8_t * /*bytes*/, size_t /*length*/,
+		picoquic_call_back_event_t event, void *callback_ctx, void * /*v_stream_ctx*/) {
+	auto *ctx = static_cast<ClientCtx *>(callback_ctx);
+	if (ctx == nullptr) {
+		return 0;
+	}
+	switch (event) {
+		case picoquic_callback_ready:
+			if (refill_in_flight(ctx) != 0) {
+				return -1;
+			}
+			break;
+		case picoquic_callback_datagram_acked:
+			ctx->datagrams_acked++;
+			if (refill_in_flight(ctx) != 0) {
+				return -1;
+			}
+			break;
+		case picoquic_callback_datagram_lost:
+			ctx->datagrams_lost++;
+			if (refill_in_flight(ctx) != 0) {
+				return -1;
+			}
+			break;
+		case picoquic_callback_datagram_spurious:
+			// Previously thought-lost packet did make it. Reclassify.
+			if (ctx->datagrams_lost > 0) {
+				ctx->datagrams_lost--;
+			}
+			ctx->datagrams_acked++;
+			break;
+		case picoquic_callback_close:
+		case picoquic_callback_application_close:
+		case picoquic_callback_stateless_reset:
+			picoquic_set_callback(cnx, nullptr, nullptr);
+			break;
+		default:
+			break;
+	}
+	return 0;
+}
+
+inline int server_loop_cb(picoquic_quic_t * /*quic*/, picoquic_packet_loop_cb_enum /*cb_mode*/,
+		void * /*callback_ctx*/, void * /*callback_arg*/) {
+	return 0;
+}
+
+struct ClientLoopState {
+	ClientCtx *client = nullptr;
+	uint64_t deadline_us = 0;
+};
+
+inline int client_loop_cb(picoquic_quic_t * /*quic*/, picoquic_packet_loop_cb_enum cb_mode,
+		void *callback_ctx, void *callback_arg) {
+	auto *state = static_cast<ClientLoopState *>(callback_ctx);
+	if (state == nullptr || state->client == nullptr) {
+		return PICOQUIC_ERROR_UNEXPECTED_ERROR;
+	}
+	const uint64_t now_us = picoquic_current_time();
+	if (state->deadline_us != 0 && now_us > state->deadline_us) {
+		std::fprintf(stderr, "picoquic_loopback: client deadline exceeded — forcing exit\n");
+		return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+	}
+	// Once close has been initiated, exit on the next callback of any
+	// kind so the test isn't stuck waiting for after_send during
+	// picoquic's draining state.
+	if (state->client->close_called) {
+		return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
+	}
+	switch (cb_mode) {
+		case picoquic_packet_loop_ready: {
+			// Enable time_check so we get periodic wake-ups even when
+			// there's no send/receive activity (needed to fire the
+			// drain-grace timeout after all datagrams have been
+			// queued + ack'd).
+			auto *options = static_cast<picoquic_packet_loop_options_t *>(callback_arg);
+			if (options != nullptr) {
+				options->do_time_check = 1;
+			}
+		} break;
+		case picoquic_packet_loop_time_check: {
+			// Cap the proposed wait so we re-check the drain timeout
+			// at least every 100 ms.
+			auto *arg = static_cast<packet_loop_time_check_arg_t *>(callback_arg);
+			if (arg != nullptr) {
+				constexpr int64_t kMaxDeltaUs = 100'000;
+				if (arg->delta_t > kMaxDeltaUs || arg->delta_t < 0) {
+					arg->delta_t = kMaxDeltaUs;
+				}
+			}
+		} break;
+		case picoquic_packet_loop_after_send:
+			if (state->client->datagrams_queued < state->client->target_count) {
+				if (refill_in_flight(state->client) != 0) {
+					return PICOQUIC_ERROR_UNEXPECTED_ERROR;
+				}
+				return 0;
+			}
+			break;
+		default:
+			break;
+	}
+	// Once queueing is done, close when every queued datagram has
+	// been resolved (acked or definitively lost), or when no progress
+	// has been made for stall_grace_us. Closing too early cancels
+	// in-flight datagrams — picoquic_close transitions the cnx into
+	// disconnecting state and drops any frames still in the send
+	// queue. The stall fallback bounds the wait if picoquic doesn't
+	// surface a `datagram_lost` callback for stuck frames.
+	if (state->client->datagrams_queued >= state->client->target_count) {
+		const int resolved = state->client->datagrams_acked + state->client->datagrams_lost;
+		if (state->client->all_queued_at_us == 0) {
+			state->client->all_queued_at_us = now_us;
+			state->client->last_progress_us = now_us;
+			state->client->last_progress_count = resolved;
+		}
+		if (resolved > state->client->last_progress_count) {
+			state->client->last_progress_count = resolved;
+			state->client->last_progress_us = now_us;
+		}
+		const bool all_resolved = resolved >= state->client->target_count;
+		const bool stalled = (now_us - state->client->last_progress_us) > state->client->stall_grace_us;
+		if (all_resolved || stalled) {
+			picoquic_close(state->client->cnx, 0);
+			state->client->close_called = true;
+			state->client->done_marked_us = now_us;
+		}
+	}
+	return 0;
+}
+
+inline int pick_free_udp_port() {
+	int fd = ::socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0) {
+		return -1;
+	}
+	sockaddr_in addr{};
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_port = 0;
+	if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+		::close(fd);
+		return -1;
+	}
+	socklen_t len = sizeof(addr);
+	if (::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) != 0) {
+		::close(fd);
+		return -1;
+	}
+	int port = ntohs(addr.sin_port);
+	::close(fd);
+	return port;
+}
+
+inline LoopbackResult run_picoquic_loopback(const LoopbackConfig &cfg) {
+	LoopbackResult result;
+	const int server_port = pick_free_udp_port();
+	if (server_port <= 0) {
+		std::fprintf(stderr, "FAIL: pick_free_udp_port failed\n");
+		return result;
+	}
+
+	ServerCtx server_ctx;
+	const uint64_t now_us = picoquic_current_time();
+	picoquic_quic_t *server_quic = picoquic_create(
+			8,
+			PICOQUIC_LOOPBACK_CERT_PATH,
+			PICOQUIC_LOOPBACK_KEY_PATH,
+			nullptr,
+			kAlpn,
+			server_callback, &server_ctx,
+			nullptr, nullptr, nullptr,
+			now_us, nullptr,
+			nullptr, nullptr, 0);
+	if (server_quic == nullptr) {
+		std::fprintf(stderr, "FAIL: server picoquic_create failed\n");
+		return result;
+	}
+	picoquic_set_default_tp_value(server_quic, picoquic_tp_max_datagram_frame_size, kMaxDatagramFrameSize);
+	// Short max_idle_timeout so the server's select() in
+	// picoquic_packet_loop_select bounds its wait — closing the
+	// wake-up pipe from another thread does not reliably interrupt
+	// select() on macOS, so we rely on idle-timeout for teardown.
+	picoquic_set_default_tp_value(server_quic, picoquic_tp_idle_timeout, 1000);
+
+	picoquic_packet_loop_param_t loop_param{};
+	loop_param.local_port = static_cast<uint16_t>(server_port);
+	loop_param.local_af = AF_INET;
+	loop_param.socket_buffer_size = cfg.socket_buffer_size;
+
+	int thread_ret = 0;
+	picoquic_network_thread_ctx_t *server_thread = picoquic_start_network_thread(
+			server_quic, &loop_param, server_loop_cb, nullptr, &thread_ret);
+	if (server_thread == nullptr || thread_ret != 0) {
+		std::fprintf(stderr, "FAIL: picoquic_start_network_thread = %d\n", thread_ret);
+		picoquic_free(server_quic);
+		return result;
+	}
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+	ClientCtx client_ctx;
+	client_ctx.target_count = cfg.datagram_count;
+	client_ctx.target_size = cfg.datagram_size;
+	client_ctx.in_flight_window = cfg.in_flight_window;
+	picoquic_quic_t *client_quic = picoquic_create(
+			1,
+			nullptr, nullptr, nullptr,
+			kAlpn,
+			nullptr, nullptr,
+			nullptr, nullptr, nullptr,
+			now_us, nullptr,
+			nullptr, nullptr, 0);
+	if (client_quic == nullptr) {
+		std::fprintf(stderr, "FAIL: client picoquic_create failed\n");
+		picoquic_delete_network_thread(server_thread);
+		picoquic_free(server_quic);
+		return result;
+	}
+	picoquic_set_default_tp_value(client_quic, picoquic_tp_max_datagram_frame_size, kMaxDatagramFrameSize);
+	picoquic_set_null_verifier(client_quic);
+
+	sockaddr_in server_addr{};
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	server_addr.sin_port = htons(static_cast<uint16_t>(server_port));
+
+	picoquic_cnx_t *cnx = picoquic_create_cnx(
+			client_quic,
+			picoquic_null_connection_id, picoquic_null_connection_id,
+			reinterpret_cast<sockaddr *>(&server_addr),
+			now_us, 0, kSni, kAlpn, /*client_mode=*/1);
+	if (cnx == nullptr) {
+		std::fprintf(stderr, "FAIL: picoquic_create_cnx failed\n");
+		picoquic_delete_network_thread(server_thread);
+		picoquic_free(client_quic);
+		picoquic_free(server_quic);
+		return result;
+	}
+	client_ctx.cnx = cnx;
+	picoquic_set_callback(cnx, client_callback, &client_ctx);
+	// Enable keep-alive so the last data datagram's ack isn't held
+	// indefinitely by picoquic's ack-delay timer waiting for the
+	// next outbound packet to piggyback on.
+	picoquic_enable_keep_alive(cnx, 50'000); // 50 ms PING interval
+
+	int rc = picoquic_start_client_cnx(cnx);
+	if (rc != 0) {
+		std::fprintf(stderr, "FAIL: picoquic_start_client_cnx = %d\n", rc);
+		picoquic_delete_network_thread(server_thread);
+		picoquic_free(client_quic);
+		picoquic_free(server_quic);
+		return result;
+	}
+
+	uint64_t timeout_ms = cfg.test_timeout_ms;
+	if (timeout_ms == 0) {
+		// Derive a generous deadline so even very large stress configs
+		// don't deadlock. 2 seconds baseline + 5 ms per datagram covers
+		// 1k datagrams in ~7 s even on a slow CI runner.
+		timeout_ms = 2'000 + static_cast<uint64_t>(cfg.datagram_count) * 5;
+	}
+	ClientLoopState loop_state;
+	loop_state.client = &client_ctx;
+	loop_state.deadline_us = picoquic_current_time() + timeout_ms * 1000;
+
+	const auto t_start = std::chrono::steady_clock::now();
+	rc = picoquic_packet_loop(client_quic, 0, AF_INET, 0, cfg.socket_buffer_size, 0,
+			client_loop_cb, &loop_state);
+	const auto t_loop_end = std::chrono::steady_clock::now();
+
+	if (rc != 0 && rc != PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP) {
+		std::fprintf(stderr, "WARN: picoquic_packet_loop returned %d\n", rc);
+	}
+	if (client_ctx.datagrams_acked < cfg.datagram_count) {
+		result.timed_out = true;
+	}
+
+	picoquic_wake_up_network_thread(server_thread);
+	picoquic_delete_network_thread(server_thread);
+	picoquic_free(client_quic);
+	picoquic_free(server_quic);
+	result.elapsed_ms = std::chrono::duration<double, std::milli>(t_loop_end - t_start).count();
+
+	std::vector<std::vector<uint8_t>> received;
+	{
+		std::lock_guard<std::mutex> lock(server_ctx.mu);
+		received = std::move(server_ctx.received);
+	}
+	result.datagrams_queued = client_ctx.datagrams_queued;
+	result.datagrams_acked = client_ctx.datagrams_acked;
+	result.datagrams_received = static_cast<int>(received.size());
+	result.server_connections_seen = server_ctx.connections_seen.load();
+
+	std::vector<bool> seen(cfg.datagram_count, false);
+	std::vector<uint8_t> expected(cfg.datagram_size);
+	for (const auto &dg : received) {
+		if (dg.size() != cfg.datagram_size) {
+			++result.payload_mismatches;
+			continue;
+		}
+		const uint32_t seq = static_cast<uint32_t>(dg[0]) |
+				(static_cast<uint32_t>(dg[1]) << 8) |
+				(static_cast<uint32_t>(dg[2]) << 16) |
+				(static_cast<uint32_t>(dg[3]) << 24);
+		if (seq >= static_cast<uint32_t>(cfg.datagram_count)) {
+			++result.payload_mismatches;
+			continue;
+		}
+		seen[seq] = true;
+		fill_payload(expected.data(), expected.size(), static_cast<int>(seq));
+		if (std::memcmp(dg.data(), expected.data(), cfg.datagram_size) != 0) {
+			++result.payload_mismatches;
+		}
+	}
+	for (int i = 0; i < cfg.datagram_count; ++i) {
+		if (!seen[i]) {
+			++result.missing_sequences;
+		}
+	}
+	return result;
+}
+} // namespace picoquic_loopback

--- a/tests/net_loopback/picoquic_loopback_test.cpp
+++ b/tests/net_loopback/picoquic_loopback_test.cpp
@@ -1,373 +1,60 @@
 // CHI-101 Phase A — net_loopback step 4b: real picoquic datagram loopback.
 //
-// Replaces the in-process NetMiddleware with an actual two-context
-// UDP loopback over QUIC:
+// Sanity-check driver: stand up a real two-context UDP loopback over
+// QUIC and confirm 32 datagrams round-trip byte-exact. The heavy
+// lifting lives in `picoquic_loopback_core.h`; this binary fixes the
+// parameters at (count=32, size=64) so it stays fast in CI.
 //
-//   * Server runs in a background thread via
-//     picoquic_start_network_thread, bound to 127.0.0.1:<ephemeral>.
-//   * Client runs picoquic_packet_loop on the main thread.
-//   * Both contexts negotiate max_datagram_frame_size via the
-//     picoquic_tp_max_datagram_frame_size transport parameter.
-//   * Client queues N datagrams via picoquic_queue_datagram_frame on
-//     picoquic_callback_ready and counts acks via
-//     picoquic_callback_datagram_acked.
-//   * Server collects payloads via picoquic_callback_datagram into a
-//     mutex-protected vector.
-//
-// The test asserts that the server received exactly N datagrams with
-// payloads matching what the client sent. This closes the
-// vendoring-smoke loop (sub-pass 4a) into a real round-trip and is
-// the foundation for routing the speech engine through an actual
-// QUIC datagram channel in follow-up work.
-//
-// Uses the picoquic-shipped test cert (CN=test.example.com) at
-// $picoquic_SOURCE_DIR/certs/{cert,key}.pem, injected via the
-// PICOQUIC_LOOPBACK_CERT_PATH / _KEY_PATH compile definitions. The
-// client installs picoquic_set_null_verifier because the test cert
-// is not signed by any real CA.
+// Wider count + payload sweeps live in `picoquic_stress_test.cpp`.
 
-#include <picoquic.h>
-#include <picoquic_packet_loop.h>
+#include "picoquic_loopback_core.h"
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <unistd.h>
-
-#include <atomic>
-#include <chrono>
-#include <cstdint>
 #include <cstdio>
-#include <cstring>
-#include <mutex>
-#include <thread>
-#include <vector>
-
-#ifndef PICOQUIC_LOOPBACK_CERT_PATH
-#error "PICOQUIC_LOOPBACK_CERT_PATH must be defined by the build"
-#endif
-#ifndef PICOQUIC_LOOPBACK_KEY_PATH
-#error "PICOQUIC_LOOPBACK_KEY_PATH must be defined by the build"
-#endif
-
-namespace {
-constexpr const char *kAlpn = "voice-loopback";
-constexpr const char *kSni = "test.example.com";
-constexpr int kDatagramCount = 32;
-constexpr size_t kDatagramSize = 64;
-constexpr uint32_t kMaxDatagramFrameSize = 1500;
-constexpr uint64_t kCloseGraceUs = 200'000; // 200 ms
-
-struct ServerCtx {
-	std::mutex mu;
-	std::vector<std::vector<uint8_t>> received;
-	std::atomic<int> connections_seen{ 0 };
-};
-
-struct ClientCtx {
-	picoquic_cnx_t *cnx = nullptr;
-	int datagrams_queued = 0;
-	int datagrams_acked = 0;
-	bool ready = false;
-	uint64_t done_marked_us = 0;
-	bool close_called = false;
-};
-
-void fill_payload(uint8_t *buf, size_t len, int seq) {
-	std::memset(buf, 0, len);
-	buf[0] = static_cast<uint8_t>(seq & 0xff);
-	buf[1] = static_cast<uint8_t>((seq >> 8) & 0xff);
-	buf[2] = static_cast<uint8_t>((seq >> 16) & 0xff);
-	buf[3] = static_cast<uint8_t>((seq >> 24) & 0xff);
-	for (size_t b = 4; b < len; ++b) {
-		buf[b] = static_cast<uint8_t>((seq + b) & 0xff);
-	}
-}
-
-int server_callback(picoquic_cnx_t *cnx,
-		uint64_t /*stream_id*/, uint8_t *bytes, size_t length,
-		picoquic_call_back_event_t event, void *callback_ctx, void * /*v_stream_ctx*/) {
-	auto *ctx = static_cast<ServerCtx *>(callback_ctx);
-	if (ctx == nullptr) {
-		return 0;
-	}
-	switch (event) {
-		case picoquic_callback_almost_ready:
-		case picoquic_callback_ready:
-			ctx->connections_seen.fetch_add(1, std::memory_order_release);
-			break;
-		case picoquic_callback_datagram: {
-			std::lock_guard<std::mutex> lock(ctx->mu);
-			ctx->received.emplace_back(bytes, bytes + length);
-		} break;
-		case picoquic_callback_close:
-		case picoquic_callback_application_close:
-		case picoquic_callback_stateless_reset:
-			picoquic_set_callback(cnx, nullptr, nullptr);
-			break;
-		default:
-			break;
-	}
-	return 0;
-}
-
-int client_callback(picoquic_cnx_t *cnx,
-		uint64_t /*stream_id*/, uint8_t * /*bytes*/, size_t /*length*/,
-		picoquic_call_back_event_t event, void *callback_ctx, void * /*v_stream_ctx*/) {
-	auto *ctx = static_cast<ClientCtx *>(callback_ctx);
-	if (ctx == nullptr) {
-		return 0;
-	}
-	switch (event) {
-		case picoquic_callback_ready: {
-			ctx->ready = true;
-			uint8_t payload[kDatagramSize];
-			for (int i = 0; i < kDatagramCount; ++i) {
-				fill_payload(payload, sizeof(payload), i);
-				int rc = picoquic_queue_datagram_frame(cnx, sizeof(payload), payload);
-				if (rc != 0) {
-					std::fprintf(stderr, "picoquic_queue_datagram_frame[%d] = %d\n", i, rc);
-					return -1;
-				}
-				ctx->datagrams_queued++;
-			}
-		} break;
-		case picoquic_callback_datagram_acked:
-			ctx->datagrams_acked++;
-			break;
-		case picoquic_callback_close:
-		case picoquic_callback_application_close:
-		case picoquic_callback_stateless_reset:
-			picoquic_set_callback(cnx, nullptr, nullptr);
-			break;
-		default:
-			break;
-	}
-	return 0;
-}
-
-// Background thread invokes the loop callback for wake-up and a few
-// other events even when we don't subscribe to them, so we have to
-// supply a non-null callback that just returns 0.
-int server_loop_cb(picoquic_quic_t * /*quic*/, picoquic_packet_loop_cb_enum /*cb_mode*/,
-		void * /*callback_ctx*/, void * /*callback_arg*/) {
-	return 0;
-}
-
-int client_loop_cb(picoquic_quic_t * /*quic*/, picoquic_packet_loop_cb_enum cb_mode,
-		void *callback_ctx, void * /*callback_arg*/) {
-	auto *ctx = static_cast<ClientCtx *>(callback_ctx);
-	if (ctx == nullptr) {
-		return PICOQUIC_ERROR_UNEXPECTED_ERROR;
-	}
-	if (cb_mode == picoquic_packet_loop_after_send || cb_mode == picoquic_packet_loop_after_receive) {
-		if (ctx->datagrams_acked >= kDatagramCount) {
-			const uint64_t now_us = picoquic_current_time();
-			if (!ctx->close_called) {
-				picoquic_close(ctx->cnx, 0);
-				ctx->close_called = true;
-				ctx->done_marked_us = now_us;
-			} else if (now_us - ctx->done_marked_us > kCloseGraceUs) {
-				return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
-			}
-		}
-	}
-	return 0;
-}
-
-int pick_free_udp_port() {
-	int fd = ::socket(AF_INET, SOCK_DGRAM, 0);
-	if (fd < 0) {
-		return -1;
-	}
-	sockaddr_in addr{};
-	addr.sin_family = AF_INET;
-	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-	addr.sin_port = 0;
-	if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
-		::close(fd);
-		return -1;
-	}
-	socklen_t len = sizeof(addr);
-	if (::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) != 0) {
-		::close(fd);
-		return -1;
-	}
-	int port = ntohs(addr.sin_port);
-	::close(fd);
-	return port;
-}
-} // namespace
 
 int main() {
+	using namespace picoquic_loopback;
+
 	std::printf("picoquic_loopback: starting (picoquic %s)\n", PICOQUIC_VERSION);
 
-	const int server_port = pick_free_udp_port();
-	if (server_port <= 0) {
-		std::fprintf(stderr, "FAIL: pick_free_udp_port failed\n");
-		return 1;
-	}
-	std::printf("picoquic_loopback: server bound port = %d\n", server_port);
+	LoopbackConfig cfg;
+	cfg.datagram_count = 32;
+	cfg.datagram_size = 64;
 
-	ServerCtx server_ctx;
-	const uint64_t now_us = picoquic_current_time();
-	picoquic_quic_t *server_quic = picoquic_create(
-			8,
-			PICOQUIC_LOOPBACK_CERT_PATH,
-			PICOQUIC_LOOPBACK_KEY_PATH,
-			nullptr,
-			kAlpn,
-			server_callback, &server_ctx,
-			nullptr, nullptr, nullptr,
-			now_us, nullptr,
-			nullptr, nullptr, 0);
-	if (server_quic == nullptr) {
-		std::fprintf(stderr, "FAIL: server picoquic_create failed\n");
-		return 1;
-	}
-	picoquic_set_default_tp_value(server_quic, picoquic_tp_max_datagram_frame_size, kMaxDatagramFrameSize);
+	const LoopbackResult r = run_picoquic_loopback(cfg);
 
-	picoquic_packet_loop_param_t loop_param{};
-	loop_param.local_port = static_cast<uint16_t>(server_port);
-	loop_param.local_af = AF_INET;
-
-	int thread_ret = 0;
-	picoquic_network_thread_ctx_t *server_thread = picoquic_start_network_thread(
-			server_quic, &loop_param, server_loop_cb, nullptr, &thread_ret);
-	if (server_thread == nullptr || thread_ret != 0) {
-		std::fprintf(stderr, "FAIL: picoquic_start_network_thread = %d\n", thread_ret);
-		picoquic_free(server_quic);
-		return 1;
-	}
-
-	// Give the server thread a moment to come up and bind its socket.
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-	ClientCtx client_ctx;
-	picoquic_quic_t *client_quic = picoquic_create(
-			1,
-			nullptr, nullptr, nullptr,
-			kAlpn,
-			nullptr, nullptr,
-			nullptr, nullptr, nullptr,
-			now_us, nullptr,
-			nullptr, nullptr, 0);
-	if (client_quic == nullptr) {
-		std::fprintf(stderr, "FAIL: client picoquic_create failed\n");
-		picoquic_delete_network_thread(server_thread);
-		picoquic_free(server_quic);
-		return 1;
-	}
-	picoquic_set_default_tp_value(client_quic, picoquic_tp_max_datagram_frame_size, kMaxDatagramFrameSize);
-	picoquic_set_null_verifier(client_quic);
-
-	sockaddr_in server_addr{};
-	server_addr.sin_family = AF_INET;
-	server_addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-	server_addr.sin_port = htons(static_cast<uint16_t>(server_port));
-
-	picoquic_cnx_t *cnx = picoquic_create_cnx(
-			client_quic,
-			picoquic_null_connection_id, picoquic_null_connection_id,
-			reinterpret_cast<sockaddr *>(&server_addr),
-			now_us, 0, kSni, kAlpn, /*client_mode=*/1);
-	if (cnx == nullptr) {
-		std::fprintf(stderr, "FAIL: picoquic_create_cnx failed\n");
-		picoquic_delete_network_thread(server_thread);
-		picoquic_free(client_quic);
-		picoquic_free(server_quic);
-		return 1;
-	}
-	client_ctx.cnx = cnx;
-	picoquic_set_callback(cnx, client_callback, &client_ctx);
-
-	int rc = picoquic_start_client_cnx(cnx);
-	if (rc != 0) {
-		std::fprintf(stderr, "FAIL: picoquic_start_client_cnx = %d\n", rc);
-		picoquic_delete_network_thread(server_thread);
-		picoquic_free(client_quic);
-		picoquic_free(server_quic);
-		return 1;
-	}
-
-	rc = picoquic_packet_loop(client_quic, 0, AF_INET, 0, 0, 0,
-			client_loop_cb, &client_ctx);
-	if (rc != 0 && rc != PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP) {
-		std::fprintf(stderr, "WARN: picoquic_packet_loop returned %d\n", rc);
-	}
-
-	// Give the server one tick to drain the close before we tear it down.
-	picoquic_wake_up_network_thread(server_thread);
-	std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-	picoquic_delete_network_thread(server_thread);
-	picoquic_free(client_quic);
-	picoquic_free(server_quic);
-
-	int received_count = 0;
-	std::vector<std::vector<uint8_t>> received;
-	{
-		std::lock_guard<std::mutex> lock(server_ctx.mu);
-		received_count = static_cast<int>(server_ctx.received.size());
-		received = server_ctx.received;
-	}
-
-	std::printf("picoquic_loopback: queued=%d acked=%d server_received=%d (connections=%d)\n",
-			client_ctx.datagrams_queued, client_ctx.datagrams_acked, received_count,
-			server_ctx.connections_seen.load());
+	std::printf("picoquic_loopback: queued=%d acked=%d received=%d connections=%d elapsed=%.1f ms\n",
+			r.datagrams_queued, r.datagrams_acked, r.datagrams_received,
+			r.server_connections_seen, r.elapsed_ms);
 
 	int fails = 0;
-	if (client_ctx.datagrams_queued != kDatagramCount) {
-		std::fprintf(stderr, "FAIL: client queued %d datagrams (expected %d)\n",
-				client_ctx.datagrams_queued, kDatagramCount);
+	if (r.timed_out) {
+		std::fprintf(stderr, "FAIL: client deadline exceeded\n");
 		++fails;
 	}
-	if (received_count != kDatagramCount) {
-		std::fprintf(stderr, "FAIL: server received %d datagrams (expected %d)\n",
-				received_count, kDatagramCount);
+	if (r.datagrams_queued != cfg.datagram_count) {
+		std::fprintf(stderr, "FAIL: queued %d (expected %d)\n", r.datagrams_queued, cfg.datagram_count);
 		++fails;
 	}
-	if (server_ctx.connections_seen.load() == 0) {
+	if (r.datagrams_received != cfg.datagram_count) {
+		std::fprintf(stderr, "FAIL: received %d (expected %d)\n", r.datagrams_received, cfg.datagram_count);
+		++fails;
+	}
+	if (r.server_connections_seen == 0) {
 		std::fprintf(stderr, "FAIL: server never reached picoquic_callback_ready\n");
 		++fails;
 	}
-
-	std::vector<bool> seen(kDatagramCount, false);
-	for (size_t i = 0; i < received.size(); ++i) {
-		const auto &dg = received[i];
-		if (dg.size() != kDatagramSize) {
-			std::fprintf(stderr, "FAIL: datagram[%zu] size=%zu (expected %zu)\n",
-					i, dg.size(), kDatagramSize);
-			++fails;
-			continue;
-		}
-		const uint32_t seq = static_cast<uint32_t>(dg[0]) |
-				(static_cast<uint32_t>(dg[1]) << 8) |
-				(static_cast<uint32_t>(dg[2]) << 16) |
-				(static_cast<uint32_t>(dg[3]) << 24);
-		if (seq >= static_cast<uint32_t>(kDatagramCount)) {
-			std::fprintf(stderr, "FAIL: datagram[%zu] decoded seq=%u out of range\n", i, seq);
-			++fails;
-			continue;
-		}
-		seen[seq] = true;
-		uint8_t expected[kDatagramSize];
-		fill_payload(expected, sizeof(expected), static_cast<int>(seq));
-		if (std::memcmp(dg.data(), expected, kDatagramSize) != 0) {
-			std::fprintf(stderr, "FAIL: datagram[%zu] payload mismatch for seq=%u\n", i, seq);
-			++fails;
-		}
+	if (r.payload_mismatches != 0) {
+		std::fprintf(stderr, "FAIL: %d payload mismatches\n", r.payload_mismatches);
+		++fails;
 	}
-	for (int i = 0; i < kDatagramCount; ++i) {
-		if (!seen[i]) {
-			std::fprintf(stderr, "FAIL: server never received seq=%d\n", i);
-			++fails;
-		}
+	if (r.missing_sequences != 0) {
+		std::fprintf(stderr, "FAIL: %d missing sequences\n", r.missing_sequences);
+		++fails;
 	}
 
 	if (fails == 0) {
 		std::printf("picoquic_loopback: PASS — %d datagrams round-tripped over real QUIC\n",
-				kDatagramCount);
+				cfg.datagram_count);
 		return 0;
 	}
 	std::fprintf(stderr, "picoquic_loopback: %d FAIL\n", fails);

--- a/tests/net_loopback/picoquic_stress_test.cpp
+++ b/tests/net_loopback/picoquic_stress_test.cpp
@@ -1,0 +1,103 @@
+// CHI-101 Phase A — net_loopback step 4c: picoquic datagram stress sweep.
+//
+// Drives the same client / server / packet-loop harness as
+// `picoquic_loopback_test.cpp` but sweeps several (count, payload
+// size) configurations to exercise:
+//
+//   * High datagram counts (queue management, ack pacing).
+//   * Large payloads up to ~MTU (transport-layer fragmentation).
+//   * The combination of both (sustained throughput).
+//
+// QUIC datagrams are unreliable by design — like raw UDP they can
+// be dropped at the kernel socket buffer or by picoquic if a frame
+// won't fit in the current send MTU. The stress sweep asserts:
+//
+//   * No payload corruption: every received datagram matches
+//     `fill_payload` byte-for-byte. (Hard requirement.)
+//   * Loss rate < 50% per config. Loopback over localhost should be
+//     near-perfect on small configs; bursty large-payload configs
+//     may shed packets at the UDP recv buffer. This bound is a
+//     regression guard, not a performance promise.
+//   * Server sees the connection establish (1+ ready callbacks).
+
+#include "picoquic_loopback_core.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+struct StressRow {
+	const char *label;
+	int count;
+	size_t size;
+	int max_missing; // hard-fail threshold per config
+};
+} // namespace
+
+int main() {
+	using namespace picoquic_loopback;
+
+	std::printf("picoquic_stress: starting (picoquic %s)\n", PICOQUIC_VERSION);
+
+	// Per-config max_missing keeps the test deterministic-enough on
+	// CI runners while still flagging real regressions (e.g. handshake
+	// failure shows up as "0 received").
+	const std::vector<StressRow> rows = {
+		// Small bursts: byte-exact, no loss expected.
+		{ "baseline   ", 32, 64, 0 },
+		// High count with small payloads: sustained pacing test.
+		{ "high-count ", 256, 64, 0 },
+		// Mid-size payloads: under-MTU comfortably.
+		{ "mid-size   ", 128, 512, 0 },
+		// Near-MTU payloads (~800 + 21 byte frame overhead + 8 byte
+		// cnxid = 829 of 1252 MTU). One deterministic drop on macOS
+		// at seq 5 (picoquic PMTU probe artifact); cap allowance at 2.
+		{ "near-mtu   ", 64, 800, 2 },
+		// Very high count: 1024 datagrams, exercises queue growth +
+		// ack pipelining over the connection.
+		{ "very-high  ", 1024, 64, 0 },
+	};
+
+	int total_fails = 0;
+	std::printf("%-12s | %5s | %5s | %7s %7s %7s | %7s | %8s | %8s\n",
+			"label", "count", "size", "queued", "acked", "rcvd", "missing", "mismatch", "ms");
+	std::printf("-------------+-------+-------+-------------------------+---------+----------+---------\n");
+
+	for (const auto &row : rows) {
+		LoopbackConfig cfg;
+		cfg.datagram_count = row.count;
+		cfg.datagram_size = row.size;
+
+		const LoopbackResult r = run_picoquic_loopback(cfg);
+
+		int fails = 0;
+		if (r.datagrams_queued != row.count) {
+			++fails;
+		}
+		if (r.server_connections_seen == 0) {
+			++fails;
+		}
+		if (r.payload_mismatches != 0) {
+			++fails;
+		}
+		if (r.missing_sequences > row.max_missing) {
+			++fails;
+		}
+
+		std::printf("%-12s | %5d | %5zu | %7d %7d %7d | %7d | %8d | %8.1f%s\n",
+				row.label, row.count, row.size,
+				r.datagrams_queued, r.datagrams_acked, r.datagrams_received,
+				r.missing_sequences, r.payload_mismatches,
+				r.elapsed_ms,
+				(fails == 0) ? "  OK" : "  FAIL");
+		total_fails += fails;
+	}
+
+	if (total_fails == 0) {
+		std::printf("\npicoquic_stress: PASS — all %zu configurations within loss bounds\n", rows.size());
+		return 0;
+	}
+	std::fprintf(stderr, "\npicoquic_stress: %d FAIL across %zu configurations\n",
+			total_fails, rows.size());
+	return 1;
+}


### PR DESCRIPTION
## Summary

Refactors the real-QUIC loopback from PR #35 into a shared harness (\`picoquic_loopback_core.h\`) and adds a stress driver that sweeps five (count, payload size) configurations to exercise the picoquic datagram path under load:

- baseline:   32 × 64
- high-count: 256 × 64
- mid-size:   128 × 512
- near-mtu:   64 × 800
- very-high:  1024 × 64

Each config asserts byte-exact payloads, connection establishment, and a per-config loss bound.

### Harness changes (also benefit the basic 4b loopback)

- **Window-based pacing** (\`refill_in_flight\`): keep at most N (default 2) unacked datagrams in flight, refill on every \`picoquic_callback_datagram_acked\`. The PR #35 "queue all on ready" pattern overran the kernel loopback UDP buffer on larger configs.
- **Track \`datagram_lost\` + \`datagram_spurious\`** so the close gate fires on \`acked + lost == target_count\` rather than on \`acked\` alone.
- **Stall-based close**: \`picoquic_close\` is called either when every datagram is resolved or when no ack/lost progress has been made for 2 s. Closing too early cancels in-flight datagrams (picoquic discards on disconnecting-state transition).
- **\`max_idle_timeout = 1 s\`** on the server so background-thread teardown isn't blocked waiting for the default 30 s idle. macOS doesn't reliably interrupt select() when the wake-up pipe FDs are closed from another thread.
- **\`picoquic_enable_keep_alive(50 ms)\`** on the client so the last data datagram's ack isn't held by picoquic's ack-delay timer.
- **\`do_time_check\`** + delta_t cap at 100 ms in the loop callback so close-condition checks fire even when there's no send/receive activity.

### Notable artifact

Near-mtu (64 × 800 B) has a **deterministic 1-frame drop at seq 5** on macOS — looks like a picoquic PMTU probe quirk on Apple Silicon. Captured in the row's max_missing=2 budget.

### Timing

- Basic loopback: **0.3 s** (was 10 s on PR #35 — the old code waited out picoquic's draining state because the close grace never re-fired during idle).
- Stress sweep: **3.8 s** wall clock.

## Test plan

- [x] \`net_loopback_picoquic_datagram\` PASS in 0.3 s on macOS Apple Silicon.
- [x] \`net_loopback_picoquic_stress\` PASS — all 5 configurations within loss bounds, 3.8 s wall.
- [x] No regression in \`net_loopback_hello\`, \`_driver\`, \`_dashboard_smoke\`, \`_observer\`, \`_picoquic_smoke\` (full build green).
- [x] Each stress row verified across 5 repeated runs.
- [ ] CI \`net_loopback (FTXUI vendor, ubuntu-latest)\` green.
- [ ] CI \`net_loopback (FTXUI vendor, macos-latest)\` green.