### PR TITLE
CHI-122: bound apt-get install steps with timeout-minutes + retries

### DIFF
--- a/.github/workflows/godot_free_ci.yml
+++ b/.github/workflows/godot_free_ci.yml
@@ -79,10 +79,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cmake + ninja + opus + libsamplerate + openssl
+        timeout-minutes: 5
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
-            sudo apt-get update
-            sudo apt-get install -y cmake ninja-build libopus-dev libsamplerate0-dev libssl-dev pkg-config
+            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+            sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y \
+              cmake ninja-build libopus-dev libsamplerate0-dev libssl-dev pkg-config
           else
             brew install cmake ninja opus libsamplerate openssl@3 pkg-config
           fi
@@ -182,9 +184,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install opus + libsamplerate
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libopus-dev libsamplerate0-dev pkg-config cmake ninja-build
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y \
+            libopus-dev libsamplerate0-dev pkg-config cmake ninja-build
 
       - name: Configure CMake
         working-directory: tests/godot_audio_model

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -10,8 +10,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install dependencies
+        timeout-minutes: 5
         run: |
-          sudo apt-get install -qq dos2unix recode clang-format
+          sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -qq \
+            dos2unix recode clang-format
 
       - name: File formatting checks (file_format.sh)
         run: |


### PR DESCRIPTION
## Summary

Patch the three apt-get install steps in CI on three axes:

- \`timeout-minutes: 5\` per step — bounds the worst-case instead of letting a wedged install pin the runner for the default 6 h.
- \`Acquire::Retries=3\` — apt retries each fetch up to 3 times.
- \`Acquire::http::Timeout=30\` — 30 s per-request timeout so a slow mirror fails over fast.

Closes [CHI-122](https://linear.app/chibifire/issue/CHI-122/godot-free-ci-apt-get-install-hangs-on-ubuntu-latest-runners-audio).

## Why

The \`Audio model (Linux)\` job hung on \`sudo apt-get install\` twice in a row on [PR #38](https://github.com/V-Sekai/godot-speech/pull/38):

| Attempt | Step duration                              | Outcome                |
|--------:|--------------------------------------------|------------------------|
| Run 1   | 17+ min, still in_progress                 | Cancelled manually     |
| Run 2   | 5 min 5 s (vs ~30 s baseline)             | Eventually succeeded   |

The same step lives in \`net_loopback (Linux)\` and \`Static Checks Formatting\`. All three patched.

## Test plan

- [x] \`python3 -m yaml\` parse OK on both edited workflows.
- [ ] CI \`godot_free_ci\` matrix green on this PR. (No behavior change on healthy runs — apt-get just gets a bounded retry budget.)
- [ ] CI \`Static Checks Formatting\` green.